### PR TITLE
Added handling of denied permissions

### DIFF
--- a/webrtc/videoroom/assets/css/app.scss
+++ b/webrtc/videoroom/assets/css/app.scss
@@ -233,6 +233,13 @@ $media-controls-height: 80px;
   background-color: black;
 }
 
+.DisabledControlIcon {
+  svg {
+    stroke: #a2071d;
+  }
+  pointer-events: none;
+}
+
 .ControlIcon {
   cursor: pointer;
   margin-right: 3 * $space;

--- a/webrtc/videoroom/assets/src/consts.ts
+++ b/webrtc/videoroom/assets/src/consts.ts
@@ -1,5 +1,10 @@
-export const MEDIA_CONSTRAINTS: MediaStreamConstraints = {
+export const AUDIO_MEDIA_CONSTRAINTS: MediaStreamConstraints = {
   audio: true,
+  video: false,
+};
+
+export const VIDEO_MEDIA_CONSTRAINTS: MediaStreamConstraints = {
+  audio: false,
   video: { width: 640, height: 360, frameRate: 24 },
 };
 

--- a/webrtc/videoroom/assets/src/room_ui.ts
+++ b/webrtc/videoroom/assets/src/room_ui.ts
@@ -22,11 +22,15 @@ interface SetupOptions {
   state?: State;
   muteAudio?: boolean;
   muteVideo?: boolean;
+  enableAudio: boolean;
+  enableVideo: boolean;
 }
 
 export function setupRoomUI({
   muteAudio = false,
   muteVideo = false,
+  enableAudio,
+  enableVideo,
   state: newState,
 }: SetupOptions): void {
   state = {
@@ -34,7 +38,7 @@ export function setupRoomUI({
     ...newState,
   };
   updateScreensharingToggleButton(true, "start");
-  setupMediaControls(muteAudio, muteVideo);
+  setupMediaControls(muteAudio, muteVideo, enableAudio, enableVideo);
 }
 
 export function setLocalScreenSharingStatus(active: boolean): void {
@@ -232,9 +236,19 @@ export function toggleControl(control: "mic" | "video") {
   }
 }
 
-function setupMediaControls(muteAudio: boolean, muteVideo: boolean) {
+function setupMediaControls(
+  muteAudio: boolean,
+  muteVideo: boolean,
+  enableAudio: boolean,
+  enableVideo: boolean
+) {
   const muteAudioEl = document.getElementById("mic-on")! as HTMLDivElement;
   const unmuteAudioEl = document.getElementById("mic-off")! as HTMLDivElement;
+
+  if (!enableAudio) {
+    muteAudioEl.classList.add("DisabledControlIcon");
+    unmuteAudioEl.classList.add("DisabledControlIcon");
+  }
 
   const toggleAudio = () => {
     state.onToggleAudio?.();
@@ -250,6 +264,12 @@ function setupMediaControls(muteAudio: boolean, muteVideo: boolean) {
 
   const muteVideoEl = document.getElementById("video-on")! as HTMLDivElement;
   const unmuteVideoEl = document.getElementById("video-off")! as HTMLDivElement;
+
+  if (!enableVideo) {
+    muteVideoEl.classList.add("DisabledControlIcon");
+    unmuteVideoEl.classList.add("DisabledControlIcon");
+  }
+
   muteVideoEl.onclick = toggleVideo;
   unmuteVideoEl.onclick = toggleVideo;
 

--- a/webrtc/videoroom/assets/src/utils.ts
+++ b/webrtc/videoroom/assets/src/utils.ts
@@ -1,0 +1,15 @@
+export function createFakeVideoStream({
+  width = 1,
+  height = 1,
+}: {
+  width: number;
+  height: number;
+}): MediaStream {
+  const canvas = document.createElement("canvas") as HTMLCanvasElement;
+  const ctx = canvas.getContext("2d");
+  if (ctx) {
+    ctx.fillStyle = "rgba(0,0,0,0)";
+    ctx.fillRect(0, 0, width, height);
+  }
+  return canvas.captureStream(0);
+}

--- a/webrtc/videoroom/lib/videoroom/display_engine.ex
+++ b/webrtc/videoroom/lib/videoroom/display_engine.ex
@@ -68,6 +68,17 @@ defmodule VideoRoom.DisplayEngine do
   @spec vad_notification(state :: t(), vad :: boolean(), endpoint_id :: Endpoint.id()) ::
           {actions :: [], state :: t()}
   def vad_notification(state, vad, endpoint_id) do
+    with %Endpoint{} = endpoint <- state.endpoints[endpoint_id],
+         video_tracks_count when video_tracks_count > 0 <-
+           Endpoint.get_video_tracks(endpoint) |> length() do
+      handle_vad_notification(state, vad, endpoint_id)
+    else
+      _ ->
+        {[], state}
+    end
+  end
+
+  defp handle_vad_notification(state, vad, endpoint_id) do
     {actions, display_managers} =
       state.display_managers
       |> Map.delete(endpoint_id)

--- a/webrtc/videoroom/lib/videoroom/display_manager.ex
+++ b/webrtc/videoroom/lib/videoroom/display_manager.ex
@@ -137,7 +137,8 @@ defmodule VideoRoom.DisplayManager do
         {:ok, state}
 
       true ->
-        raise("No such endpoint id #{inspect(endpoint_id)}")
+        # endpoint may have no video tracks therefore it is not present in display manager
+        {:ok, state}
     end
   end
 

--- a/webrtc/videoroom/lib/videoroom/pipeline.ex
+++ b/webrtc/videoroom/lib/videoroom/pipeline.ex
@@ -128,6 +128,9 @@ defmodule VideoRoom.Pipeline do
       links = new_peer_links(peer_type, endpoint_bin, ctx, state)
 
       tracks_msgs =
+      if tracks == [] do
+        []
+      else
         flat_map_children(ctx, fn
           {:endpoint, other_peer_pid} = endpoint_bin
           when other_peer_pid != state.active_screensharing ->
@@ -136,6 +139,7 @@ defmodule VideoRoom.Pipeline do
           _child ->
             []
         end)
+      end
 
       spec = %ParentSpec{children: children, links: links}
 
@@ -271,7 +275,7 @@ defmodule VideoRoom.Pipeline do
       {endpoint, state} = pop_in(state, [:endpoints, peer_pid])
       {actions, display_engine} = DisplayEngine.remove_endpoint(state.display_engine, endpoint)
       state = %{state | display_engine: display_engine}
-      tracks = Enum.map(Endpoint.get_tracks(endpoint), &%Track{&1 | active?: false})
+      tracks = Enum.map(Endpoint.get_tracks(endpoint), &%Track{&1 | enabled?: false})
 
       children =
         Endpoint.get_tracks(endpoint)

--- a/webrtc/videoroom/lib/videoroom/pipeline.ex
+++ b/webrtc/videoroom/lib/videoroom/pipeline.ex
@@ -128,18 +128,18 @@ defmodule VideoRoom.Pipeline do
       links = new_peer_links(peer_type, endpoint_bin, ctx, state)
 
       tracks_msgs =
-      if tracks == [] do
-        []
-      else
-        flat_map_children(ctx, fn
-          {:endpoint, other_peer_pid} = endpoint_bin
-          when other_peer_pid != state.active_screensharing ->
-            [forward: {endpoint_bin, {:add_tracks, tracks}}]
+        if tracks == [] do
+          []
+        else
+          flat_map_children(ctx, fn
+            {:endpoint, other_peer_pid} = endpoint_bin
+            when other_peer_pid != state.active_screensharing ->
+              [forward: {endpoint_bin, {:add_tracks, tracks}}]
 
-          _child ->
-            []
-        end)
-      end
+            _child ->
+              []
+          end)
+        end
 
       spec = %ParentSpec{children: children, links: links}
 

--- a/webrtc/videoroom/lib/videoroom/pipeline.ex
+++ b/webrtc/videoroom/lib/videoroom/pipeline.ex
@@ -72,9 +72,17 @@ defmodule VideoRoom.Pipeline do
     {:ok, state}
   end
 
+  # `opts` keyword list must contain following fields:
+  # * `display_name` - label used to identify participant/screensharing
+  # * `relay_video?` - true|false whether video track should be created
+  # * `relay_audio?` - true|false whether audio track should be created
+  #
+  # IMPORTANT: relay_video? and relay_audio? are ignored for screensharing and video track is created instead
   @impl true
-  def handle_other({:new_peer, peer_pid, peer_type, display_name, ref}, ctx, state) do
+  def handle_other({:new_peer, peer_pid, peer_type, opts, ref}, ctx, state) do
     send(peer_pid, {:new_peer, {:ok, state.max_display_num}, ref})
+
+    display_name = Keyword.fetch!(opts, :display_name)
 
     if Map.has_key?(ctx.children, {:endpoint, peer_pid}) do
       Membrane.Logger.warn("Peer already connected, ignoring")
@@ -83,13 +91,15 @@ defmodule VideoRoom.Pipeline do
       Membrane.Logger.info("New peer #{inspect(peer_pid)} of type #{inspect(peer_type)}")
       Process.monitor(peer_pid)
 
-      tracks = new_tracks(peer_type)
+      tracks = new_tracks(peer_type, opts)
 
       endpoint = Endpoint.new(peer_pid, peer_type, tracks, %{display_name: display_name})
 
       endpoint_bin = {:endpoint, peer_pid}
 
-      display_engine = DisplayEngine.add_new_endpoint(state.display_engine, endpoint)
+      display_engine =
+        DisplayEngine.add_new_endpoint(state.display_engine, endpoint) |> IO.inspect()
+
       state = %{state | display_engine: display_engine}
 
       stun_servers = Application.fetch_env!(:membrane_videoroom_demo, :stun_servers)
@@ -175,6 +185,7 @@ defmodule VideoRoom.Pipeline do
     {:endpoint, endpoint_id} = endpoint_bin
 
     endpoint = state.endpoints[endpoint_id]
+
     display_engine = DisplayEngine.add_new_track(state.display_engine, track_id, endpoint)
     state = %{state | display_engine: display_engine}
 
@@ -260,7 +271,7 @@ defmodule VideoRoom.Pipeline do
       {endpoint, state} = pop_in(state, [:endpoints, peer_pid])
       {actions, display_engine} = DisplayEngine.remove_endpoint(state.display_engine, endpoint)
       state = %{state | display_engine: display_engine}
-      tracks = Enum.map(Endpoint.get_tracks(endpoint), &%Track{&1 | enabled?: false})
+      tracks = Enum.map(Endpoint.get_tracks(endpoint), &%Track{&1 | active?: false})
 
       children =
         Endpoint.get_tracks(endpoint)
@@ -301,12 +312,19 @@ defmodule VideoRoom.Pipeline do
     ctx.children |> Map.keys() |> Enum.flat_map(fun)
   end
 
-  defp new_tracks(:participant) do
+  defp new_tracks(:participant, opts) do
     stream_id = Track.stream_id()
-    [Track.new(:audio, stream_id), Track.new(:video, stream_id)]
+
+    audio_track =
+      if Keyword.fetch!(opts, :relay_audio?), do: [Track.new(:audio, stream_id)], else: []
+
+    video_track =
+      if Keyword.fetch!(opts, :relay_video?), do: [Track.new(:video, stream_id)], else: []
+
+    audio_track ++ video_track
   end
 
-  defp new_tracks(:screensharing) do
+  defp new_tracks(:screensharing, _opts) do
     screensharing_id = "SCREEN:#{Track.stream_id()}" |> String.slice(0, 16)
     [Track.new(:video, Track.stream_id(), id: screensharing_id)]
   end

--- a/webrtc/videoroom/mix.exs
+++ b/webrtc/videoroom/mix.exs
@@ -23,7 +23,7 @@ defmodule VideoRoom.MixProject do
       # {:membrane_core, "~> 0.6.1"},
       {:membrane_core,
        github: "membraneframework/membrane_core", branch: "develop", override: true},
-      {:membrane_webrtc_plugin, path: "~/repos/membrane/membrane_webrtc_plugin"},
+      {:membrane_webrtc_plugin, github: "membraneframework/membrane_webrtc_plugin"},
       {:membrane_element_tee, "~> 0.4.1"},
       {:membrane_element_fake, "~> 0.4.0"},
       {:plug_cowboy, "~> 2.0"},

--- a/webrtc/videoroom/mix.exs
+++ b/webrtc/videoroom/mix.exs
@@ -23,7 +23,7 @@ defmodule VideoRoom.MixProject do
       # {:membrane_core, "~> 0.6.1"},
       {:membrane_core,
        github: "membraneframework/membrane_core", branch: "develop", override: true},
-      {:membrane_webrtc_plugin, github: "membraneframework/membrane_webrtc_plugin"},
+      {:membrane_webrtc_plugin, path: "~/repos/membrane/membrane_webrtc_plugin"},
       {:membrane_element_tee, "~> 0.4.1"},
       {:membrane_element_fake, "~> 0.4.0"},
       {:plug_cowboy, "~> 2.0"},


### PR DESCRIPTION
In this PR it is possible to join room without one of permissions (microphone/camera) but something seems to be broken when trying to join without both of them. Something must be blocking the flow somewhere as nothing happends for a while and then toilet overflow happens almost imediately for other peer that in this case is sending media.