### PR TITLE
Send media_event to peer only if channel is not nil

### DIFF
--- a/webrtc/videoroom/lib/videoroom/room.ex
+++ b/webrtc/videoroom/lib/videoroom/room.ex
@@ -53,7 +53,10 @@ defmodule Videoroom.Room do
 
   @impl true
   def handle_info({_sfu_engine, {:sfu_media_event, to, event}}, state) do
-    send(state.peer_channels[to], {:media_event, event})
+    if state.peer_channels[to] != nil do
+      send(state.peer_channels[to], {:media_event, event})
+    end
+
     {:noreply, state}
   end
 


### PR DESCRIPTION
Fix bug which make it possible to send message to `nil`.

It was possible to send message to `nil` in a situation when two peers left room in the same time.