### PR TITLE
Allow videoroom to run distristributed

### DIFF
--- a/webrtc/videoroom/README.md
+++ b/webrtc/videoroom/README.md
@@ -54,6 +54,42 @@ docker run -p 4000:4000 membrane_videoroom
 
 Then go to <http://localhost:4000/>.
 
+## Run distributed
+
+Videoroom demo does not automatically start a cluster, but you can check the distributed functionalities by starting one manually.
+
+Open two terminals. On the first run:
+
+```bash
+$ SERVER_PORT=4001 iex --sname one -S mix phx.server
+```
+
+On the second, run:
+
+```bash
+$ SERVER_PORT=4002 iex --sname two -S mix phx.server
+```
+
+This will start two videoroom instances, one running on port `4001` on node `one@{your-local-hostname}`
+and the other on port `4002` on node `two@{your-local-hostname}`.
+
+To create a cluster, run this on the first terminal:
+
+```elixir
+iex(one@{your-local-hostname})1> :net_kernel.connect_node(:'two@{your-local-hostname}')
+true
+```
+
+You can check that the cluster has been created with:
+
+```elixir
+iex(one@{your-local-hostname})2> :erlang.nodes()                     
+[:two@{your-local-hostname}]
+```
+
+Then, open two tabs on your browser. Go to <http://localhost:4001/> on one, and <http://localhost:4002/> on the other.
+Join the same room, and you shall see two participants in the room. Every participant EndPoint will be running on their respective node.
+
 ## Copyright and License
 
 Copyright 2020, [Software Mansion](https://swmansion.com/?utm_source=git&utm_medium=readme&utm_campaign=membrane)

--- a/webrtc/videoroom/config/runtime.exs
+++ b/webrtc/videoroom/config/runtime.exs
@@ -2,5 +2,5 @@ import Config
 
 config :membrane_videoroom_demo, VideoRoomWeb.Endpoint, [
   {:url, [host: "localhost"]},
-  {:http, [otp_app: :membrane_videoroom_demo, port: 4000]}
+  {:http, [otp_app: :membrane_videoroom_demo, port: System.get_env("SERVER_PORT") || 4000]}
 ]

--- a/webrtc/videoroom/lib/videoroom/room.ex
+++ b/webrtc/videoroom/lib/videoroom/room.ex
@@ -39,8 +39,8 @@ defmodule Videoroom.Room do
   end
 
   @impl true
-  def handle_call({:add_peer_channel, peer_channel_pid, peer_pid}, _from, state) do
-    state = put_in(state, [:peer_channels, peer_pid], peer_channel_pid)
+  def handle_call({:add_peer_channel, peer_channel_pid, peer_id}, _from, state) do
+    state = put_in(state, [:peer_channels, peer_id], peer_channel_pid)
     Process.monitor(peer_channel_pid)
     {:reply, :ok, state}
   end
@@ -62,7 +62,10 @@ defmodule Videoroom.Room do
 
   @impl true
   def handle_info({sfu_engine, {:new_peer, peer_id, _metadata, _track_metadata}}, state) do
-    send(sfu_engine, {:accept_new_peer, peer_id})
+    # get node the peer with peer_id is running on
+    peer_channel_pid = Map.get(state.peer_channels, peer_id)
+    peer_node = node(peer_channel_pid)
+    send(sfu_engine, {:accept_new_peer, peer_id, peer_node})
     {:noreply, state}
   end
 

--- a/webrtc/videoroom/lib/videoroom_web/peer_channel.ex
+++ b/webrtc/videoroom/lib/videoroom_web/peer_channel.ex
@@ -5,9 +5,9 @@ defmodule VideoRoomWeb.PeerChannel do
 
   @impl true
   def join("room:" <> room_id, _params, socket) do
-    case Registry.lookup(Videoroom.Room.Registry, room_id) do
-      [{pid, _value}] -> {:ok, pid}
-      [] -> Videoroom.Room.start(name: {:via, Registry, {Videoroom.Room.Registry, room_id}})
+    case :global.whereis_name(room_id) do
+      :undefined -> Videoroom.Room.start(name: {:global, room_id})
+      pid -> {:ok, pid}
     end
     |> case do
       {:ok, room} ->


### PR DESCRIPTION
This version allows to distribute a room across a cluster, based on the changes in https://github.com/membraneframework/membrane_rtc_engine/pull/25 and https://github.com/membraneframework/membrane_core/pull/319.