### PR TITLE
Use Kernel.send() instead of GenServer.call()

### DIFF
--- a/webrtc/videoroom/lib/videoroom/room.ex
+++ b/webrtc/videoroom/lib/videoroom/room.ex
@@ -13,10 +13,6 @@ defmodule Videoroom.Room do
     GenServer.start_link(__MODULE__, [], opts)
   end
 
-  def add_peer_channel(room, peer_channel_pid, peer_id) do
-    GenServer.call(room, {:add_peer_channel, peer_channel_pid, peer_id})
-  end
-
   @impl true
   def init(opts) do
     Membrane.Logger.info("Spawning room process: #{inspect(self())}")
@@ -43,10 +39,10 @@ defmodule Videoroom.Room do
   end
 
   @impl true
-  def handle_call({:add_peer_channel, peer_channel_pid, peer_id}, _from, state) do
+  def handle_info({:add_peer_channel, peer_channel_pid, peer_id}, state) do
     state = put_in(state, [:peer_channels, peer_id], peer_channel_pid)
     Process.monitor(peer_channel_pid)
-    {:reply, :ok, state}
+    {:noreply, state}
   end
 
   @impl true

--- a/webrtc/videoroom/lib/videoroom_web/peer_channel.ex
+++ b/webrtc/videoroom/lib/videoroom_web/peer_channel.ex
@@ -14,7 +14,7 @@ defmodule VideoRoomWeb.PeerChannel do
         peer_id = "#{UUID.uuid4()}"
         # TODO handle crash of room?
         Process.monitor(room)
-        Videoroom.Room.add_peer_channel(room, self(), peer_id)
+        send(room, {:add_peer_channel, self(), peer_id})
         {:ok, Phoenix.Socket.assign(socket, %{room_id: room_id, room: room, peer_id: peer_id})}
 
       {:error, reason} ->


### PR DESCRIPTION
closes #167
`:add_peer_channel` message in the `Videoroom.Room` module is now handled with `handle_info/2` instead of `handle_call/3`. I have also removed `Videoroom.Room.add_peer_channel/3` wrapper and changed its invocations into `Kernel.send()` invocations.
 