### PR TITLE
Add instruction to set `Keyframe Interval` in rtmp2hls readme

### DIFF
--- a/rtmp_to_hls/README.md
+++ b/rtmp_to_hls/README.md
@@ -47,6 +47,7 @@ Once you have OBS installed, you can perform the following steps:
 1. Open the OBS application
 2. Open the `Settings` windows
 3. Go to the `Stream` tab and set the value in the `Server` field to: `rtmp://localhost:9009` (the address where the server is waiting for the stream)
+4. Go to the `Output`, set output mode to `Advanced` and set `Keyframe Interval` to 2 seconds.
 4. Finally, you can go back to the main window and start streaming with the `Start Streaming` button.
  
 Below you can see how to set the appropriate settings (step 2) and 3) from the list of steps above):


### PR DESCRIPTION
A README for `rtmp_to_hls` doesn't intruct a user to set `Keyframe Interval` in OBS. Given that output is created by HLS, periodical keyframes are required to correctly split the stream into CMAF segments.

Lack of that option will result in incorrect lengths of CMAF segments. As a special case of this, the start of the HLS stream will be delayed, as the very first segment will not appear until the encoder on the sender side decides to generate a keyframe.