### PR TITLE
Update readme files

### DIFF
--- a/camera_to_hls/.gitignore
+++ b/camera_to_hls/.gitignore
@@ -26,5 +26,5 @@ erl_crash.dump
 # Ignore package tarball (built via "mix hex.build").
 membrane_demo_rtp_to_hls-*.tar
 
-# MacOS
+# macOS
 .DS_Store

--- a/camera_to_hls/README.md
+++ b/camera_to_hls/README.md
@@ -2,30 +2,94 @@
 
 This project demonstrates capturing camera video and converting it to HLS stream, which is then can be used wherever you want :)
 
-## Prerequisites
+## Prerequisites and running the demo
+
+Below is the instruction for the installation of required dependencies and how to run this demo on various operating systems:
+
+<details>
+<summary>
+<b>MacOS</b>
+</summary>
+
+### Prerequisites
 
 You must have following packages installed on your system:
 
 - FFmpeg 4.\*
 - openssl
 
-### macOS:
+Furthermore, make sure you have `Elixir` and `Erlang` installed on your machine. For installation details, see: https://elixir-lang.org/install.html
 
 ```shell
 brew install ffmpeg openssl
 ```
 
-### Ubuntu:
+### Run the demo
+
+To run the demo, clone the membrane_demo repository and checkout to the demo directory:
 
 ```shell
-apt install ffmpeg
+git clone https://github.com/membraneframework/membrane_demo
+cd membrane_demo/camera_to_hls
 ```
+
+Then you need to download the dependencies of the mix project:
+
+```shell
+mix deps.get
+```
+
+You may be asked to install `Hex` and `rebar3`.
+
+Finally, you can run the project with:
+
+```shell
+mix run --no-halt
+```
+
+CMAF header and segment files will be created in `output` directory along with HLS playlist files.
+
+To play the HLS stream you can just serve the content of `output` dir via regular HTTP server, e.g. by running in a separate terminal:
+
+```shell
+python3 -m http.server 8000
+```
+
+Then, you can open the url http://localhost:8000/output/index.m3u8 in some player, e.g. `ffplay` or `vlc`
+
+```shell
+ffplay http://localhost:8000/output/index.m3u8
+```
+
+Moreover you can open the url http://localhost:8000/stream in your browser and enjoy the video from your camera :)
+
+_You might be asked to grant access to your camera, as some operating systems require that_
+
+_In case of the absence of a physical camera, it is necessary to use a virtual camera (e.g. OBS, [see how to set up the virtual camera in OBS](https://obsproject.com/kb/virtual-camera-guide))_
+
+</details>
+
+<details>
+<summary>
+<b>Ubuntu</b>
+</summary>
+
+### Prerequisites
+
+You must have following packages installed on your system:
+
+- FFmpeg 4.\*
+- openssl
 
 Furthermore, make sure you have `Elixir` and `Erlang` installed on your machine. For installation details, see: https://elixir-lang.org/install.html
 
 On Ubuntu, we recommend installation through `asdf`, see: https://asdf-vm.com/guide/getting-started.html
 
-## Run the demo
+```shell
+apt install ffmpeg
+```
+
+### Run the demo
 
 To run the demo, clone the membrane_demo repository and checkout to the demo directory:
 
@@ -72,6 +136,9 @@ Moreover you can open the url http://localhost:8000/stream in your browser and e
 _You might be asked to grant access to your camera, as some operating systems require that_
 
 _In case of the absence of a physical camera, it is necessary to use a virtual camera (e.g. OBS, [see how to set up the virtual camera in OBS](https://obsproject.com/kb/virtual-camera-guide))_
+
+</details>
+<br>
 
 ## Copyright and License
 

--- a/camera_to_hls/README.md
+++ b/camera_to_hls/README.md
@@ -6,7 +6,7 @@ This project demonstrates capturing camera video and converting it to HLS stream
 
 You must have following packages installed on your system:
 
-- ffmpeg 4.\*
+- FFmpeg 4.\*
 - openssl
 
 ### MacOS:
@@ -29,14 +29,14 @@ On Ubuntu, we recommend installation through `asdf`, see: https://asdf-vm.com/gu
 
 To run the demo, clone the membrane_demo repository and checkout to the demo directory:
 
-```bash
+```shell
 git clone https://github.com/membraneframework/membrane_demo
 cd membrane_demo/camera_to_hls
 ```
 
 Then you need to download the dependencies of the mix project:
 
-```bash
+```shell
 mix deps.get
 ```
 
@@ -49,7 +49,7 @@ sudo apt-get update
 
 Finally, you can run the project with:
 
-```bash
+```shell
 mix run --no-halt
 ```
 
@@ -57,13 +57,13 @@ CMAF header and segment files will be created in `output` directory along with H
 
 To play the HLS stream you can just serve the content of `output` dir via regular HTTP server, e.g. by running in a separate terminal:
 
-```bash
+```shell
 python3 -m http.server 8000
 ```
 
 Then, you can open the url http://localhost:8000/output/index.m3u8 in some player, e.g. `ffplay` or `vlc`
 
-```bash
+```shell
 ffplay http://localhost:8000/output/index.m3u8
 ```
 
@@ -71,7 +71,7 @@ Moreover you can open the url http://localhost:8000/stream in your browser and e
 
 _You might be asked to grant access to your camera, as some operating systems require that_
 
-_In case of the absence of a physical camera, it is necessary to use a virtual camera (e.g. OBS)_
+_In case of the absence of a physical camera, it is necessary to use a virtual camera (e.g. OBS, [see how to set up the virtual camera in OBS](https://obsproject.com/kb/virtual-camera-guide))_
 
 ## Copyright and License
 

--- a/camera_to_hls/README.md
+++ b/camera_to_hls/README.md
@@ -9,15 +9,46 @@ You must have following packages installed on your system:
 - ffmpeg 4.\*
 - openssl
 
-### If using MACOS and `homebrew`:
+### MacOS:
 
 ```shell
-brew install ffmpeg
+brew install ffmpeg openssl
 ```
+
+### Ubuntu:
+
+```shell
+apt install ffmpeg
+```
+
+Furthermore, make sure you have `Elixir` and `Erlang` installed on your machine. For installation details, see: https://elixir-lang.org/install.html
+
+On Ubuntu, we recommend installation through asdf, see: https://asdf-vm.com/guide/getting-started.html
 
 ## Run the demo
 
-Run the project with:
+To run the demo, clone the membrane_demo repository and checkout to the demo directory:
+
+```
+git clone https://github.com/membraneframework/membrane_demo
+cd membrane_demo/camera_to_hls
+```
+
+Then you need to download the dependencies of the mix project:
+
+```bash
+mix deps.get
+```
+
+Then you may be asked to install `Hex` and then `rebar3`.
+
+In case of installation issues with Hex on Ubuntu, try updating the system packages first by entering the command:
+
+```shell
+sudo apt-get update
+```
+
+Finally, you can run the project with:
 
 ```bash
 mix run --no-halt
@@ -25,7 +56,7 @@ mix run --no-halt
 
 CMAF header and segment files will be created in `output` directory along with HLS playlist files.
 
-To play the HLS stream you can just serve the content of `output` dir via regular HTTP server, e.g. by running:
+To play the HLS stream you can just serve the content of `output` dir via regular HTTP server, e.g. by running in separate tab:
 
 ```bash
 python3 -m http.server 8000
@@ -40,6 +71,8 @@ ffplay http://localhost:8000/output/index.m3u8
 Moreover you can open the url http://localhost:8000/stream in your browser and enjoy the video from your camera :)
 
 _You might be asked to grant access to your camera, as some operating systems require that_
+
+_In case of the absence of a physical camera, it is necessary to use a virtual camera (e.g. OBS)_
 
 ## Copyright and License
 

--- a/camera_to_hls/README.md
+++ b/camera_to_hls/README.md
@@ -9,7 +9,7 @@ You must have following packages installed on your system:
 - FFmpeg 4.\*
 - openssl
 
-### MacOS:
+### macOS:
 
 ```shell
 brew install ffmpeg openssl

--- a/camera_to_hls/README.md
+++ b/camera_to_hls/README.md
@@ -55,7 +55,7 @@ To play the HLS stream you can just serve the content of the `output` dir via a 
 python3 -m http.server 8000
 ```
 
-Then, you can open the URL http://localhost:8000/output/index.m3u8 in some players, e.g. `ffplay` or `vlc`
+Then, you can open the URL http://localhost:8000/output/index.m3u8 in some player, e.g. `ffplay` or `vlc`
 
 ```shell
 ffplay http://localhost:8000/output/index.m3u8
@@ -127,7 +127,7 @@ To play the HLS stream you can just serve the content of the `output` dir via a 
 python3 -m http.server 8000
 ```
 
-Then, you can open the URL http://localhost:8000/output/index.m3u8 in some players, e.g. `ffplay` or `vlc`
+Then, you can open the URL http://localhost:8000/output/index.m3u8 in some player, e.g. `ffplay` or `vlc`
 
 ```shell
 ffplay http://localhost:8000/output/index.m3u8

--- a/camera_to_hls/README.md
+++ b/camera_to_hls/README.md
@@ -8,7 +8,7 @@ Below is the instruction for the installation of required dependencies and how t
 
 <details>
 <summary>
-<b>MacOS</b>
+<b>macOS</b>
 </summary>
 
 ### Prerequisites
@@ -87,6 +87,7 @@ On Ubuntu, we recommend installation through `asdf`, see: https://asdf-vm.com/gu
 
 ```shell
 apt install ffmpeg
+apt install libssl-dev
 ```
 
 ### Run the demo
@@ -105,11 +106,12 @@ mix deps.get
 ```
 
 You may be asked to install `Hex` and `rebar3`.
-In case of installation issues with `Hex` on Ubuntu, try updating the system packages first by entering the command:
 
-```shell
-sudo apt-get update
-```
+> In case of installation issues with `Hex` on Ubuntu, try updating the system packages first by entering the command:
+>
+> ```shell
+> sudo apt-get update
+> ```
 
 Finally, you can run the project with:
 
@@ -138,7 +140,6 @@ _You might be asked to grant access to your camera, as some operating systems re
 _In case of the absence of a physical camera, it is necessary to use a virtual camera (e.g. OBS, [see how to set up the virtual camera in OBS](https://obsproject.com/kb/virtual-camera-guide))_
 
 </details>
-<br>
 
 ## Copyright and License
 

--- a/camera_to_hls/README.md
+++ b/camera_to_hls/README.md
@@ -1,6 +1,6 @@
 # Membrane Demo - Camera Video to HLS
 
-This project demonstrates capturing camera video and converting it to HLS stream, which is then can be used wherever you want :)
+This project demonstrates capturing camera video and converting it to an HLS stream, which is then can be used wherever you want :)
 
 ## Prerequisites and running the demo
 
@@ -13,12 +13,12 @@ Below is the instruction for the installation of required dependencies and how t
 
 ### Prerequisites
 
-You must have following packages installed on your system:
+You must have the following packages installed on your system:
 
 - FFmpeg 4.\*
 - openssl
 
-Furthermore, make sure you have `Elixir` and `Erlang` installed on your machine. For installation details, see: https://elixir-lang.org/install.html
+Furthermore, make sure you have `Elixir` and `Erlang` installed on your machine. For installation details, see: https://elixir-lang.org/install.html
 
 ```shell
 brew install ffmpeg openssl
@@ -47,21 +47,21 @@ Finally, you can run the project with:
 mix run --no-halt
 ```
 
-CMAF header and segment files will be created in `output` directory along with HLS playlist files.
+CMAF header and segment files will be created in the `output` directory along with HLS playlist files.
 
-To play the HLS stream you can just serve the content of `output` dir via regular HTTP server, e.g. by running in a separate terminal:
+To play the HLS stream you can just serve the content of the `output` dir via a regular HTTP server, e.g. by running in a separate terminal:
 
 ```shell
 python3 -m http.server 8000
 ```
 
-Then, you can open the url http://localhost:8000/output/index.m3u8 in some player, e.g. `ffplay` or `vlc`
+Then, you can open the URL http://localhost:8000/output/index.m3u8 in some players, e.g. `ffplay` or `vlc`
 
 ```shell
 ffplay http://localhost:8000/output/index.m3u8
 ```
 
-Moreover you can open the url http://localhost:8000/stream in your browser and enjoy the video from your camera :)
+Moreover, you can open the URL http://localhost:8000/stream in your browser and enjoy the video from your camera :)
 
 _You might be asked to grant access to your camera, as some operating systems require that_
 
@@ -76,12 +76,12 @@ _In case of the absence of a physical camera, it is necessary to use a virtual c
 
 ### Prerequisites
 
-You must have following packages installed on your system:
+You must have the following packages installed on your system:
 
 - FFmpeg 4.\*
 - openssl
 
-Furthermore, make sure you have `Elixir` and `Erlang` installed on your machine. For installation details, see: https://elixir-lang.org/install.html
+Furthermore, make sure you have `Elixir` and `Erlang` installed on your machine. For installation details, see: https://elixir-lang.org/install.html
 
 On Ubuntu, we recommend installation through `asdf`, see: https://asdf-vm.com/guide/getting-started.html
 
@@ -119,21 +119,21 @@ Finally, you can run the project with:
 mix run --no-halt
 ```
 
-CMAF header and segment files will be created in `output` directory along with HLS playlist files.
+CMAF header and segment files will be created in the `output` directory along with HLS playlist files.
 
-To play the HLS stream you can just serve the content of `output` dir via regular HTTP server, e.g. by running in a separate terminal:
+To play the HLS stream you can just serve the content of the `output` dir via a regular HTTP server, e.g. by running in a separate terminal:
 
 ```shell
 python3 -m http.server 8000
 ```
 
-Then, you can open the url http://localhost:8000/output/index.m3u8 in some player, e.g. `ffplay` or `vlc`
+Then, you can open the URL http://localhost:8000/output/index.m3u8 in some players, e.g. `ffplay` or `vlc`
 
 ```shell
 ffplay http://localhost:8000/output/index.m3u8
 ```
 
-Moreover you can open the url http://localhost:8000/stream in your browser and enjoy the video from your camera :)
+Moreover, you can open the URL http://localhost:8000/stream in your browser and enjoy the video from your camera :)
 
 _You might be asked to grant access to your camera, as some operating systems require that_
 

--- a/camera_to_hls/README.md
+++ b/camera_to_hls/README.md
@@ -23,13 +23,13 @@ apt install ffmpeg
 
 Furthermore, make sure you have `Elixir` and `Erlang` installed on your machine. For installation details, see: https://elixir-lang.org/install.html
 
-On Ubuntu, we recommend installation through asdf, see: https://asdf-vm.com/guide/getting-started.html
+On Ubuntu, we recommend installation through `asdf`, see: https://asdf-vm.com/guide/getting-started.html
 
 ## Run the demo
 
 To run the demo, clone the membrane_demo repository and checkout to the demo directory:
 
-```
+```bash
 git clone https://github.com/membraneframework/membrane_demo
 cd membrane_demo/camera_to_hls
 ```
@@ -40,9 +40,8 @@ Then you need to download the dependencies of the mix project:
 mix deps.get
 ```
 
-Then you may be asked to install `Hex` and then `rebar3`.
-
-In case of installation issues with Hex on Ubuntu, try updating the system packages first by entering the command:
+You may be asked to install `Hex` and `rebar3`.
+In case of installation issues with `Hex` on Ubuntu, try updating the system packages first by entering the command:
 
 ```shell
 sudo apt-get update
@@ -56,7 +55,7 @@ mix run --no-halt
 
 CMAF header and segment files will be created in `output` directory along with HLS playlist files.
 
-To play the HLS stream you can just serve the content of `output` dir via regular HTTP server, e.g. by running in separate tab:
+To play the HLS stream you can just serve the content of `output` dir via regular HTTP server, e.g. by running in a separate terminal:
 
 ```bash
 python3 -m http.server 8000

--- a/rtmp_to_hls/.gitignore
+++ b/rtmp_to_hls/.gitignore
@@ -34,5 +34,5 @@ npm-debug.log
 
 /output
 
-# MacOS 
+# macOS 
 .DS_Store

--- a/rtmp_to_hls/README.md
+++ b/rtmp_to_hls/README.md
@@ -1,6 +1,6 @@
 # RTMP to HLS
 
-This demo is an application that is capable of receiving RTMP stream, converting it to HLS, and publishing via an HTTP server so that it can be played with a web player.
+This demo is an application that is capable of receiving an RTMP stream, converting it to HLS, and publishing via an HTTP server so that it can be played with a web player.
 
 ## Possible use cases
 
@@ -35,9 +35,9 @@ Below is the instruction for the installation of required dependencies and how t
 
 ### Prerequisites
 
-In order to successfully build and install the plugin, you need to have FFmpeg 4.\* installed on your system.
+To successfully build and install the plugin, you need to have FFmpeg 4.\* installed on your system.
 
-Furthermore, make sure you have `Elixir` and `Erlang` installed on your machine. For installation details, see: https://elixir-lang.org/install.html
+Furthermore, make sure you have `Elixir` and `Erlang` installed on your machine. For installation details, see: https://elixir-lang.org/install.html
 
 ```shell
 brew install ffmpeg
@@ -60,7 +60,7 @@ mix deps.get
 
 You may be asked to install `Hex` and then `rebar3`.
 
-> In case of issues with compilation of membrane_h264_ffmpeg_plugin, enter:
+> In case of issues with the compilation of membrane_h264_ffmpeg_plugin, enter:
 >
 > ```shell
 > mix deps.update bundlex
@@ -72,7 +72,7 @@ You may be asked to install `Hex` and then `rebar3`.
 > brew install pkg-config
 > ```
 
-Finally, you can start the phoenix server:
+Finally, you can start the Phoenix server:
 
 ```shell
 mix phx.server
@@ -89,10 +89,10 @@ Once you have OBS installed, you can perform the following steps:
 1. Open the OBS application
 2. Open the `Settings` windows
 3. Go to the `Stream` tab and set the value in the `Server` field to: `rtmp://localhost:9006` (the address where the server is waiting for the stream)
-4. Go to the `Output`, set output mode to `Advanced` and set `Keyframe Interval` to 2 seconds.
+4. Go to the `Output`, set output mode to `Advanced`, and set `Keyframe Interval` to 2 seconds.
 5. Finally, you can go back to the main window and start streaming with the `Start Streaming` button.
 
-Below you can see how to set the appropriate settings (step 2) and 3) from the list of steps above):
+Below you can see how to set the appropriate settings (steps 2) and 3) from the list of steps above):
 ![OBS settings](doc_assets/OBS_settings.webp)
 
 </details>
@@ -104,7 +104,7 @@ Below you can see how to set the appropriate settings (step 2) and 3) from the l
 
 ### Prerequisites
 
-In order to successfully build and install the plugin, you need to have FFmpeg 4.\* installed on your system.
+To successfully build and install the plugin, you need to have FFmpeg 4.\* installed on your system.
 
 ```shell
 apt install ffmpeg
@@ -137,13 +137,13 @@ You may be asked to install `Hex` and then `rebar3`.
 > sudo apt-get update
 > ```
 
-> In case of issues with compilation of membrane_h264_ffmpeg_plugin, enter:
+> In case of issues with the compilation of membrane_h264_ffmpeg_plugin, enter:
 >
 > ```shell
 > mix deps.update bundlex
 > ```
 
-Finally, you can start the phoenix server:
+Finally, you can start the Phoenix server:
 
 ```shell
 mix phx.server
@@ -160,10 +160,10 @@ Once you have OBS installed, you can perform the following steps:
 1. Open the OBS application
 2. Open the `Settings` windows
 3. Go to the `Stream` tab and set the value in the `Server` field to: `rtmp://localhost:9006` (the address where the server is waiting for the stream)
-4. Go to the `Output`, set output mode to `Advanced` and set `Keyframe Interval` to 2 seconds.
+4. Go to the `Output`, set output mode to `Advanced`, and set `Keyframe Interval` to 2 seconds.
 5. Finally, you can go back to the main window and start streaming with the `Start Streaming` button.
 
-Below you can see how to set the appropriate settings (step 2) and 3) from the list of steps above):
+Below you can see how to set the appropriate settings (steps 2) and 3) from the list of steps above):
 ![OBS settings](doc_assets/OBS_settings.webp)
 
 </details>

--- a/rtmp_to_hls/README.md
+++ b/rtmp_to_hls/README.md
@@ -35,7 +35,7 @@ Below there are some one-liner commands that will allow you to install that depe
 apt install ffmpeg
 ```
 
-### MacOS:
+### macOS:
 
 ```shell
 brew install ffmpeg
@@ -73,7 +73,7 @@ In case of issues with compilation of membrane_h264_ffmpeg_plugin, enter:
 mix deps.update bundlex
 ```
 
-and then install pkg-config (MacOS):
+and then install pkg-config (macOS):
 
 ```shell
 brew install pkg-config

--- a/rtmp_to_hls/README.md
+++ b/rtmp_to_hls/README.md
@@ -12,7 +12,7 @@ The streamer sends multimedia using RTMP, a protocol supported by popular stream
 
 The system is divided into two parts:
 
-- the server, is responsible for receiving the RTMP stream, converting it into HLS, and then publishing the created files with an HTTP server,
+- the server, which is responsible for receiving the RTMP stream, converting it into HLS, and then publishing the created files with an HTTP server,
 - the client, responsible for playing the incoming HLS stream.
 
 ### Server
@@ -26,7 +26,7 @@ The client is just a simple javascript application using the [HLS.js](https://gi
 
 ## Prerequisites
 
-In order to successfully build and install the plugin, you need to have ffmpeg 4.\* installed on your system.
+In order to successfully build and install the plugin, you need to have FFmpeg 4.\* installed on your system.
 Below there are some one-liner commands that will allow you to install that dependency on the desired OS.
 
 ### Ubuntu:
@@ -68,7 +68,7 @@ In case of installation issues with Hex on Ubuntu, try updating the system packa
 sudo apt-get update
 ```
 
-In case of issue with compilation of membrane_h264_ffmpeg_plugin, enter:
+In case of issues with compilation of membrane_h264_ffmpeg_plugin, enter:
 
 ```shell
 mix deps.update bundlex
@@ -90,7 +90,7 @@ The server will be waiting for an RTMP stream on `localhost:9006`, and the clien
 
 ### Exemplary stream generation with OBS
 
-You can send RTMP stream onto `localhost:9006` with your favorite streaming tool. However, below we present how to generate an RTMP stream with
+You can send RTMP stream onto `localhost:9006` with your favorite streaming tool. Below we present how to generate an RTMP stream with
 [OBS](https://obsproject.com).
 Once you have OBS installed, you can perform the following steps:
 

--- a/rtmp_to_hls/README.md
+++ b/rtmp_to_hls/README.md
@@ -43,7 +43,7 @@ Furthermore, make sure you have `Elixir` and `Erlang` installed on your machine.
 brew install ffmpeg
 ```
 
-## Running the demo
+### Running the demo
 
 To run the demo, clone the membrane_demo repository and checkout to the demo directory:
 
@@ -66,7 +66,7 @@ You may be asked to install `Hex` and then `rebar3`.
 > mix deps.update bundlex
 > ```
 >
-> and then install pkg-config (macOS):
+> and then install pkg-config:
 >
 > ```shell
 > brew install pkg-config
@@ -114,7 +114,7 @@ Furthermore, make sure you have `Elixir` and `Erlang` installed on your machine.
 
 On Ubuntu, we recommend installation through `asdf`, see: https://asdf-vm.com/guide/getting-started.html
 
-## Running the demo
+### Running the demo
 
 To run the demo, clone the membrane_demo repository and checkout to the demo directory:
 

--- a/rtmp_to_hls/README.md
+++ b/rtmp_to_hls/README.md
@@ -1,7 +1,9 @@
-# RTMP to HLS 
+# RTMP to HLS
+
 This demo is an application that is capable of receiving RTMP stream, converting it to HLS, and publishing via an HTTP server so that it can be played with a web player.
 
 ## Possible use cases
+
 The application presented in this demo could be used in the following scenario.
 There is one person, the so-called "streamer", and multiple "viewers", who want to see the stream of multimedia sent by the streamer.
 The streamer sends multimedia using RTMP, a protocol supported by popular streaming software (i.e. OBS). Such an RTMP stream is then converted into HLS and published by the HTTP server, which is capable of handling many HTTP requests. The viewers can then play the multimedia delivered with HTTP. Such a solution scales well because the streamer doesn't have a direct connection with any of the viewers.
@@ -9,60 +11,91 @@ The streamer sends multimedia using RTMP, a protocol supported by popular stream
 ## Architecture of the solution
 
 The system is divided into two parts:
-* the server, is responsible for receiving the RTMP stream, converting it into HLS, and then publishing the created files with an HTTP server,
-* the client, responsible for playing the incoming HLS stream.
+
+- the server, is responsible for receiving the RTMP stream, converting it into HLS, and then publishing the created files with an HTTP server,
+- the client, responsible for playing the incoming HLS stream.
 
 ### Server
+
 The internal architecture of the server is presented below:
 ![Server scheme](doc_assets/RTMP_to_HLS_pipeline.png)
 
 ### Client
+
 The client is just a simple javascript application using the [HLS.js](https://github.com/video-dev/hls.js/) web player.
 
 ## Prerequisites
-In order to successfully build and install the plugin, you need to have ffmpeg == 4.4 installed on your system. 
+
+In order to successfully build and install the plugin, you need to have ffmpeg 4.\* installed on your system.
 Below there are some one-liner commands that will allow you to install that dependency on the desired OS.
+
 ### Ubuntu:
+
 ```
-apt install ffmpeg=4.4
+apt install ffmpeg
 ```
 
 ### MacOS:
+
 ```
-brew install ffmpeg@4.4
+brew install ffmpeg
 ```
 
-Furthermore, make sure you have Elixir installed on your machine. For installation details, see: https://elixir-lang.org/install.html
+Furthermore, make sure you have `Elixir` and `Erlang` installed on your machine. For installation details, see: https://elixir-lang.org/install.html
+
+On Ubuntu, we recommend installation through asdf, see: https://asdf-vm.com/guide/getting-started.html
 
 ## Running the demo
+
 To run the demo, clone the membrane_demo repository and checkout to the demo directory:
+
 ```
 git clone https://github.com/membraneframework/membrane_demo
 cd membrane_demo/rtmp_to_hls
 ```
 
 Then you need to download the dependencies of the mix project:
+
 ```
 mix deps.get
 ```
 
+Then you may be asked to install `Hex` and then `rebar3`.
+
+In case of installation issues with Hex on Ubuntu, try updating the system packages first by entering the command:
+
+```shell
+sudo apt-get update
+```
+
+In case of issue with compilation of membrane_h264_ffmpeg_plugin, enter:
+
+```shell
+mix deps.update bundlex
+```
+
+and then install pkg-config.
+
 Finally, you can start the phoenix server:
+
 ```
 mix phx.server
 ```
 
-The server will be waiting for an RTMP stream on `localhost:9009`, and the client of the application will be available on `localhost:4000`.
+The server will be waiting for an RTMP stream on `localhost:9006`, and the client of the application will be available on `localhost:4000`.
 
 ### Exemplary stream generation with OBS
-You can send RTMP stream onto `localhost:9009` with your favorite streaming tool. However, below we present how to generate an RTMP stream with
+
+You can send RTMP stream onto `localhost:9006` with your favorite streaming tool. However, below we present how to generate an RTMP stream with
 [OBS](https://obsproject.com).
 Once you have OBS installed, you can perform the following steps:
+
 1. Open the OBS application
 2. Open the `Settings` windows
-3. Go to the `Stream` tab and set the value in the `Server` field to: `rtmp://localhost:9009` (the address where the server is waiting for the stream)
+3. Go to the `Stream` tab and set the value in the `Server` field to: `rtmp://localhost:9006` (the address where the server is waiting for the stream)
 4. Go to the `Output`, set output mode to `Advanced` and set `Keyframe Interval` to 2 seconds.
-4. Finally, you can go back to the main window and start streaming with the `Start Streaming` button.
- 
+5. Finally, you can go back to the main window and start streaming with the `Start Streaming` button.
+
 Below you can see how to set the appropriate settings (step 2) and 3) from the list of steps above):
 ![OBS settings](doc_assets/OBS_settings.webp)
 

--- a/rtmp_to_hls/README.md
+++ b/rtmp_to_hls/README.md
@@ -24,26 +24,24 @@ The internal architecture of the server is presented below:
 
 The client is just a simple javascript application using the [HLS.js](https://github.com/video-dev/hls.js/) web player.
 
-## Prerequisites
+## Prerequisites and running the demo
+
+Below is the instruction for the installation of required dependencies and how to run this demo on various operating systems:
+
+<details>
+<summary>
+<b>macOS</b>
+</summary>
+
+### Prerequisites
 
 In order to successfully build and install the plugin, you need to have FFmpeg 4.\* installed on your system.
-Below there are some one-liner commands that will allow you to install that dependency on the desired OS.
 
-### Ubuntu:
-
-```shell
-apt install ffmpeg
-```
-
-### macOS:
+Furthermore, make sure you have `Elixir` and `Erlang` installed on your machine. For installation details, see: https://elixir-lang.org/install.html
 
 ```shell
 brew install ffmpeg
 ```
-
-Furthermore, make sure you have `Elixir` and `Erlang` installed on your machine. For installation details, see: https://elixir-lang.org/install.html
-
-On Ubuntu, we recommend installation through `asdf`, see: https://asdf-vm.com/guide/getting-started.html
 
 ## Running the demo
 
@@ -61,23 +59,18 @@ mix deps.get
 ```
 
 You may be asked to install `Hex` and then `rebar3`.
-In case of installation issues with Hex on Ubuntu, try updating the system packages first by entering the command:
 
-```shell
-sudo apt-get update
-```
-
-In case of issues with compilation of membrane_h264_ffmpeg_plugin, enter:
-
-```shell
-mix deps.update bundlex
-```
-
-and then install pkg-config (macOS):
-
-```shell
-brew install pkg-config
-```
+> In case of issues with compilation of membrane_h264_ffmpeg_plugin, enter:
+>
+> ```shell
+> mix deps.update bundlex
+> ```
+>
+> and then install pkg-config (macOS):
+>
+> ```shell
+> brew install pkg-config
+> ```
 
 Finally, you can start the phoenix server:
 
@@ -101,6 +94,79 @@ Once you have OBS installed, you can perform the following steps:
 
 Below you can see how to set the appropriate settings (step 2) and 3) from the list of steps above):
 ![OBS settings](doc_assets/OBS_settings.webp)
+
+</details>
+
+<details>
+<summary>
+<b>Ubuntu</b>
+</summary>
+
+### Prerequisites
+
+In order to successfully build and install the plugin, you need to have FFmpeg 4.\* installed on your system.
+
+```shell
+apt install ffmpeg
+```
+
+Furthermore, make sure you have `Elixir` and `Erlang` installed on your machine. For installation details, see: https://elixir-lang.org/install.html
+
+On Ubuntu, we recommend installation through `asdf`, see: https://asdf-vm.com/guide/getting-started.html
+
+## Running the demo
+
+To run the demo, clone the membrane_demo repository and checkout to the demo directory:
+
+```shell
+git clone https://github.com/membraneframework/membrane_demo
+cd membrane_demo/rtmp_to_hls
+```
+
+Then you need to download the dependencies of the mix project:
+
+```shell
+mix deps.get
+```
+
+You may be asked to install `Hex` and then `rebar3`.
+
+> In case of installation issues with Hex on Ubuntu, try updating the system packages first by entering the command:
+>
+> ```shell
+> sudo apt-get update
+> ```
+
+> In case of issues with compilation of membrane_h264_ffmpeg_plugin, enter:
+>
+> ```shell
+> mix deps.update bundlex
+> ```
+
+Finally, you can start the phoenix server:
+
+```shell
+mix phx.server
+```
+
+The server will be waiting for an RTMP stream on `localhost:9006`, and the client of the application will be available on `localhost:4000`.
+
+### Exemplary stream generation with OBS
+
+You can send RTMP stream onto `localhost:9006` with your favorite streaming tool. Below we present how to generate an RTMP stream with
+[OBS](https://obsproject.com).
+Once you have OBS installed, you can perform the following steps:
+
+1. Open the OBS application
+2. Open the `Settings` windows
+3. Go to the `Stream` tab and set the value in the `Server` field to: `rtmp://localhost:9006` (the address where the server is waiting for the stream)
+4. Go to the `Output`, set output mode to `Advanced` and set `Keyframe Interval` to 2 seconds.
+5. Finally, you can go back to the main window and start streaming with the `Start Streaming` button.
+
+Below you can see how to set the appropriate settings (step 2) and 3) from the list of steps above):
+![OBS settings](doc_assets/OBS_settings.webp)
+
+</details>
 
 ## Copyright and License
 

--- a/rtmp_to_hls/README.md
+++ b/rtmp_to_hls/README.md
@@ -74,7 +74,11 @@ In case of issue with compilation of membrane_h264_ffmpeg_plugin, enter:
 mix deps.update bundlex
 ```
 
-and then install pkg-config.
+and then install pkg-config (MacOS):
+
+```
+brew install pkg-config
+```
 
 Finally, you can start the phoenix server:
 

--- a/rtmp_to_hls/README.md
+++ b/rtmp_to_hls/README.md
@@ -31,37 +31,36 @@ Below there are some one-liner commands that will allow you to install that depe
 
 ### Ubuntu:
 
-```
+```shell
 apt install ffmpeg
 ```
 
 ### MacOS:
 
-```
+```shell
 brew install ffmpeg
 ```
 
 Furthermore, make sure you have `Elixir` and `Erlang` installed on your machine. For installation details, see: https://elixir-lang.org/install.html
 
-On Ubuntu, we recommend installation through asdf, see: https://asdf-vm.com/guide/getting-started.html
+On Ubuntu, we recommend installation through `asdf`, see: https://asdf-vm.com/guide/getting-started.html
 
 ## Running the demo
 
 To run the demo, clone the membrane_demo repository and checkout to the demo directory:
 
-```
+```shell
 git clone https://github.com/membraneframework/membrane_demo
 cd membrane_demo/rtmp_to_hls
 ```
 
 Then you need to download the dependencies of the mix project:
 
-```
+```shell
 mix deps.get
 ```
 
-Then you may be asked to install `Hex` and then `rebar3`.
-
+You may be asked to install `Hex` and then `rebar3`.
 In case of installation issues with Hex on Ubuntu, try updating the system packages first by entering the command:
 
 ```shell
@@ -76,13 +75,13 @@ mix deps.update bundlex
 
 and then install pkg-config (MacOS):
 
-```
+```shell
 brew install pkg-config
 ```
 
 Finally, you can start the phoenix server:
 
-```
+```shell
 mix phx.server
 ```
 

--- a/rtp/README.md
+++ b/rtp/README.md
@@ -5,7 +5,16 @@ This project demonstrates handling RTP in Membrane.
 This example uses [RTP plugin](https://github.com/membraneframework/membrane_rtp_plugin) that is responsible for
 receiving and sending RTP streams.
 
-## Prerequisites
+## Prerequisites and running the demo
+
+Below is the instruction for the installation of required dependencies and how to run this demo on various operating systems:
+
+<details>
+<summary>
+<b>macOS</b>
+</summary>
+
+### Prerequisites
 
 Make sure you have the following packages installed in your system:
 
@@ -13,23 +22,13 @@ Make sure you have the following packages installed in your system:
 - SDL 2
 - PortAudio
 
-### Ubuntu:
-
-```shell
-apt install ffmpeg portaudio19-dev libsdl2-dev
-```
-
-### macOS:
-
 ```shell
 brew install ffmpeg portaudio sdl2
 ```
 
 Furthermore, make sure you have `Elixir` and `Erlang` installed on your machine. For installation details, see: https://elixir-lang.org/install.html
 
-On Ubuntu, we recommend installation through `asdf`, see: https://asdf-vm.com/guide/getting-started.html
-
-## Run the demo
+### Run the demo
 
 To run the demo, clone the membrane_demo repository and checkout to the demo directory:
 
@@ -45,50 +44,31 @@ mix deps.get
 ```
 
 You may be asked to install `Hex` and then `rebar3`.
-In case of installation issues with Hex on Ubuntu, try updating the system packages first by entering the command:
 
-```shell
-sudo apt-get update
-```
+> In case of issues with compilation of ex_libsrtp, enter:
+>
+> ```shell
+> mix deps.update bundlex
+> ```
+>
+> and then install pkg-config and srtp:
+>
+> ```shell
+> brew install pkg-config srtp
+> ```
 
-In case of issues with compilation of ex_libsrtp, enter:
-
-```shell
-mix deps.update bundlex
-```
-
-and then install pkg-config and srtp (macOS):
-
-```shell
-brew install pkg-config srtp
-```
-
-In case of issues with compilation of membrane_opus_plugin, install `opus`:
-
-### macOS:
-
-```shell
-brew install opus
-```
-
-and if you have macOS M1/M2 (Apple silicon) add following lines to your `~/.zshrc` file:
-
-```shell
-export C_INCLUDE_PATH=$C_INCLUDE_PATH:$(brew --cellar)/opus/1.3.1/include
-export LIBRARY_PATH=$LIBRARY_PATH:$(brew --cellar)/opus/1.3.1/lib
-```
-
-### Ubuntu:
-
-```shell
-apt install libopus-dev
-```
-
-and then install `libavcodec`:
-
-```shell
-apt install libavcodec-dev
-```
+> In case of issues with compilation of membrane_opus_plugin, install `opus`:
+>
+> ```shell
+> brew install opus
+> ```
+>
+> and if you have macOS M1/M2 (Apple silicon) add following lines to your `~/.zshrc` file:
+>
+> ```shell
+> export C_INCLUDE_PATH=$C_INCLUDE_PATH:$(brew --cellar)/opus/1.3.1/include
+> export LIBRARY_PATH=$LIBRARY_PATH:$(brew --cellar)/opus/1.3.1/lib
+> ```
 
 Finally, you can run the demo:
 
@@ -116,6 +96,99 @@ and launch gstreamer:
 gst-launch-1.0 -v audiotestsrc ! audio/x-raw,rate=48000,channels=2 ! opusenc ! rtpopuspay pt=120 ! udpsink host=127.0.0.1 port=5002\
     videotestsrc ! video/x-raw,format=I420 ! x264enc key-int-max=10 tune=zerolatency ! rtph264pay pt=96 ! udpsink host=127.0.0.1 port=5000
 ```
+
+</details>
+
+<details>
+<summary>
+<b>Ubuntu</b>
+</summary>
+
+### Prerequisites
+
+Make sure you have the following packages installed in your system:
+
+- FFmpeg 4.x
+- SDL 2
+- PortAudio
+
+```shell
+apt install ffmpeg portaudio19-dev libsdl2-dev
+```
+
+Furthermore, make sure you have `Elixir` and `Erlang` installed on your machine. For installation details, see: https://elixir-lang.org/install.html
+
+On Ubuntu, we recommend installation through `asdf`, see: https://asdf-vm.com/guide/getting-started.html
+
+### Run the demo
+
+To run the demo, clone the membrane_demo repository and checkout to the demo directory:
+
+```shell
+git clone https://github.com/membraneframework/membrane_demo
+cd membrane_demo/rtp
+```
+
+Then you need to download the dependencies of the mix project:
+
+```shell
+mix deps.get
+```
+
+You may be asked to install `Hex` and then `rebar3`.
+
+> In case of installation issues with Hex on Ubuntu, try updating the system packages first by entering the command:
+>
+> ```shell
+> sudo apt-get update
+> ```
+
+> In case of issues with compilation of ex_libsrtp, enter:
+>
+> ```shell
+> mix deps.update bundlex
+> ```
+
+> In case of issues with compilation of membrane_opus_plugin, install `opus`:
+>
+> ```shell
+> apt install libopus-dev
+> ```
+>
+> and then install `libavcodec`:
+>
+> ```shell
+> apt install libavcodec-dev
+> ```
+
+Finally, you can run the demo:
+
+- Open a terminal in the project directory
+- Type: `mix run --no-halt receive.exs`
+- Open another terminal in the project directory
+- Type: `mix run --no-halt send.exs`
+
+You should be able to see an SDL player showing an example video.
+
+The sender pipeline (run with `send.exs`) takes sample audio and video files and sends them with RTP.
+The receiving pipeline (run with `receive.exs`) depayloads the audio and video streams and plays them.
+
+If you wish to stream using SRTP, add `--secure` flag when running both `receive.exs` and `send.exs`.
+
+Alternatively, the stream can be sent using [gstreamer](https://gstreamer.freedesktop.org/). In this case, you only need to start the receiving pipeline:
+
+```shell
+mix run --no-halt receive.exs
+```
+
+and launch gstreamer:
+
+```shell
+gst-launch-1.0 -v audiotestsrc ! audio/x-raw,rate=48000,channels=2 ! opusenc ! rtpopuspay pt=120 ! udpsink host=127.0.0.1 port=5002\
+    videotestsrc ! video/x-raw,format=I420 ! x264enc key-int-max=10 tune=zerolatency ! rtph264pay pt=96 ! udpsink host=127.0.0.1 port=5000
+```
+
+</details>
 
 ## Copyright and License
 

--- a/rtp/README.md
+++ b/rtp/README.md
@@ -7,7 +7,7 @@ receiving and sending RTP streams.
 
 ## Prerequisites
 
-You have to have installed the following packages on your system:
+Make sure to have the following packages installed in your system:
 
 - FFmpeg 4.x
 - SDL 2

--- a/rtp/README.md
+++ b/rtp/README.md
@@ -69,6 +69,8 @@ You may be asked to install `Hex` and then `rebar3`.
 > export C_INCLUDE_PATH=$C_INCLUDE_PATH:$(brew --cellar)/opus/1.3.1/include
 > export LIBRARY_PATH=$LIBRARY_PATH:$(brew --cellar)/opus/1.3.1/lib
 > ```
+>
+> and restart your terminal.
 
 Finally, you can run the demo:
 

--- a/rtp/README.md
+++ b/rtp/README.md
@@ -7,7 +7,7 @@ receiving and sending RTP streams.
 
 ## Prerequisites
 
-Make sure to have the following packages installed in your system:
+Make sure you have the following packages installed in your system:
 
 - FFmpeg 4.x
 - SDL 2
@@ -19,7 +19,7 @@ Make sure to have the following packages installed in your system:
 apt install ffmpeg portaudio19-dev libsdl2-dev
 ```
 
-### MacOS:
+### macOS:
 
 ```shell
 brew install ffmpeg portaudio sdl2
@@ -57,7 +57,7 @@ In case of issues with compilation of ex_libsrtp, enter:
 mix deps.update bundlex
 ```
 
-and then install pkg-config and srtp (MacOS):
+and then install pkg-config and srtp (macOS):
 
 ```shell
 brew install pkg-config srtp
@@ -65,13 +65,13 @@ brew install pkg-config srtp
 
 In case of issues with compilation of membrane_opus_plugin, install `opus`:
 
-### MacOS:
+### macOS:
 
 ```shell
 brew install opus
 ```
 
-and if you have MacOS M1/M2 (Apple silicon) add following lines to your `~/.zshrc` file:
+and if you have macOS M1/M2 (Apple silicon) add following lines to your `~/.zshrc` file:
 
 ```shell
 export C_INCLUDE_PATH=$C_INCLUDE_PATH:$(brew --cellar)/opus/1.3.1/include

--- a/rtp/README.md
+++ b/rtp/README.md
@@ -9,38 +9,99 @@ receiving and sending RTP streams.
 
 You have to have installed the following packages on your system:
 
-* FFmpeg 4.x
-* SDL 2
-* PortAudio
+- FFmpeg 4.x
+- SDL 2
+- PortAudio
 
-One-liner for Ubuntu:
+### Ubuntu:
+
 ```bash
 apt install ffmpeg portaudio19-dev libsdl2-dev
 ```
-One-liner for MacOS:
+
+### MacOS:
+
 ```bash
 brew install ffmpeg portaudio sdl2
 ```
 
-Then, install mix dependencies:
+Furthermore, make sure you have `Elixir` and `Erlang` installed on your machine. For installation details, see: https://elixir-lang.org/install.html
 
-```bash
-mix deps.get
-```
+On Ubuntu, we recommend installation through asdf, see: https://asdf-vm.com/guide/getting-started.html
 
 ## Run the demo
 
-* Open a terminal in the project directory
-* Type `mix run --no-halt receive.exs`
-* Open another terminal in the project directory
-* Type: `mix run --no-halt send.exs`
+To run the demo, clone the membrane_demo repository and checkout to the demo directory:
+
+```
+git clone https://github.com/membraneframework/membrane_demo
+cd membrane_demo/rtp
+```
+
+Then you need to download the dependencies of the mix project:
+
+```
+mix deps.get
+```
+
+Then you may be asked to install `Hex` and then `rebar3`.
+
+In case of installation issues with Hex on Ubuntu, try updating the system packages first by entering the command:
+
+```shell
+sudo apt-get update
+```
+
+In case of issue with compilation of ex_libsrtp, enter:
+
+```shell
+mix deps.update bundlex
+```
+
+and then install pkg-config and srtp (MacOS):
+
+```
+brew install pkg-config srtp
+```
+
+In case of issue with compilation of membrane_opus_plugin, install `opus`:
+
+### MacOS:
+
+```
+brew install opus
+```
+
+and if you have MacOS M1/M2 (Apple silicon) add following lines to your `~/.zshrc` file:
+
+```
+export C_INCLUDE_PATH=$C_INCLUDE_PATH:$(brew --cellar)/opus/1.3.1/include
+export LIBRARY_PATH=$LIBRARY_PATH:$(brew --cellar)/opus/1.3.1/lib
+```
+
+### Ubuntu:
+
+```
+apt install libopus-dev
+```
+
+and then install `libavcodec`:
+
+```
+apt install libavcodec-dev
+```
+
+Finally, you can run the demo:
+
+- Open a terminal in the project directory
+- Type: `mix run --no-halt receive.exs`
+- Open another terminal in the project directory
+- Type: `mix run --no-halt send.exs`
 
 You should be able to see an SDL player showing an example video.
 
-The sender pipeline (run with `send.exs`) takes sample audio and video files 
-and sends them with RTP.
+The sender pipeline (run with `send.exs`) takes sample audio and video files and sends them with RTP.
 The receiving pipeline (run with `receive.exs`) depayloads the audio and video streams and plays them.
-
 
 If you wish to stream using SRTP, add `--secure` flag when running both `receive.exs` and `send.exs`.
 

--- a/rtp/README.md
+++ b/rtp/README.md
@@ -45,7 +45,7 @@ mix deps.get
 
 You may be asked to install `Hex` and then `rebar3`.
 
-> In case of issues with compilation of ex_libsrtp, enter:
+> In case of issues with the compilation of ex_libsrtp, enter:
 >
 > ```shell
 > mix deps.update bundlex
@@ -84,7 +84,7 @@ You should be able to see an SDL player showing an example video.
 The sender pipeline (run with `send.exs`) takes sample audio and video files and sends them with RTP.
 The receiving pipeline (run with `receive.exs`) depayloads the audio and video streams and plays them.
 
-If you wish to stream using SRTP, add `--secure` flag when running both `receive.exs` and `send.exs`.
+If you wish to stream using SRTP, add a `--secure` flag when running both `receive.exs` and `send.exs`.
 
 Alternatively, the stream can be sent using [gstreamer](https://gstreamer.freedesktop.org/). In this case, you only need to start the receiving pipeline:
 
@@ -145,7 +145,7 @@ You may be asked to install `Hex` and then `rebar3`.
 > sudo apt-get update
 > ```
 
-> In case of issues with compilation of ex_libsrtp, enter:
+> In case of issues with the compilation of ex_libsrtp, enter:
 >
 > ```shell
 > mix deps.update bundlex
@@ -175,7 +175,7 @@ You should be able to see an SDL player showing an example video.
 The sender pipeline (run with `send.exs`) takes sample audio and video files and sends them with RTP.
 The receiving pipeline (run with `receive.exs`) depayloads the audio and video streams and plays them.
 
-If you wish to stream using SRTP, add `--secure` flag when running both `receive.exs` and `send.exs`.
+If you wish to stream using SRTP, add a `--secure` flag when running both `receive.exs` and `send.exs`.
 
 Alternatively, the stream can be sent using [gstreamer](https://gstreamer.freedesktop.org/). In this case, you only need to start the receiving pipeline:
 

--- a/rtp/README.md
+++ b/rtp/README.md
@@ -15,44 +15,43 @@ Make sure to have the following packages installed in your system:
 
 ### Ubuntu:
 
-```bash
+```shell
 apt install ffmpeg portaudio19-dev libsdl2-dev
 ```
 
 ### MacOS:
 
-```bash
+```shell
 brew install ffmpeg portaudio sdl2
 ```
 
 Furthermore, make sure you have `Elixir` and `Erlang` installed on your machine. For installation details, see: https://elixir-lang.org/install.html
 
-On Ubuntu, we recommend installation through asdf, see: https://asdf-vm.com/guide/getting-started.html
+On Ubuntu, we recommend installation through `asdf`, see: https://asdf-vm.com/guide/getting-started.html
 
 ## Run the demo
 
 To run the demo, clone the membrane_demo repository and checkout to the demo directory:
 
-```
+```shell
 git clone https://github.com/membraneframework/membrane_demo
 cd membrane_demo/rtp
 ```
 
 Then you need to download the dependencies of the mix project:
 
-```
+```shell
 mix deps.get
 ```
 
-Then you may be asked to install `Hex` and then `rebar3`.
-
+You may be asked to install `Hex` and then `rebar3`.
 In case of installation issues with Hex on Ubuntu, try updating the system packages first by entering the command:
 
 ```shell
 sudo apt-get update
 ```
 
-In case of issue with compilation of ex_libsrtp, enter:
+In case of issues with compilation of ex_libsrtp, enter:
 
 ```shell
 mix deps.update bundlex
@@ -60,34 +59,34 @@ mix deps.update bundlex
 
 and then install pkg-config and srtp (MacOS):
 
-```
+```shell
 brew install pkg-config srtp
 ```
 
-In case of issue with compilation of membrane_opus_plugin, install `opus`:
+In case of issues with compilation of membrane_opus_plugin, install `opus`:
 
 ### MacOS:
 
-```
+```shell
 brew install opus
 ```
 
 and if you have MacOS M1/M2 (Apple silicon) add following lines to your `~/.zshrc` file:
 
-```
+```shell
 export C_INCLUDE_PATH=$C_INCLUDE_PATH:$(brew --cellar)/opus/1.3.1/include
 export LIBRARY_PATH=$LIBRARY_PATH:$(brew --cellar)/opus/1.3.1/lib
 ```
 
 ### Ubuntu:
 
-```
+```shell
 apt install libopus-dev
 ```
 
 and then install `libavcodec`:
 
-```
+```shell
 apt install libavcodec-dev
 ```
 
@@ -107,13 +106,13 @@ If you wish to stream using SRTP, add `--secure` flag when running both `receive
 
 Alternatively, the stream can be sent using [gstreamer](https://gstreamer.freedesktop.org/). In this case, you only need to start the receiving pipeline:
 
-```bash
+```shell
 mix run --no-halt receive.exs
 ```
 
 and launch gstreamer:
 
-```bash
+```shell
 gst-launch-1.0 -v audiotestsrc ! audio/x-raw,rate=48000,channels=2 ! opusenc ! rtpopuspay pt=120 ! udpsink host=127.0.0.1 port=5002\
     videotestsrc ! video/x-raw,format=I420 ! x264enc key-int-max=10 tune=zerolatency ! rtph264pay pt=96 ! udpsink host=127.0.0.1 port=5000
 ```

--- a/rtp_to_hls/.gitignore
+++ b/rtp_to_hls/.gitignore
@@ -24,5 +24,5 @@ erl_crash.dump
 # Ignore package tarball (built via "mix hex.build").
 membrane_demo_rtp_to_hls-*.tar
 
-# MacOS
+# macOS
 .DS_Store

--- a/rtp_to_hls/README.md
+++ b/rtp_to_hls/README.md
@@ -15,7 +15,7 @@ You must have following packages installed on your system:
 - GStreamer > 1.0 to provide RTP streams
 - python3 for running simple Web Server
 
-### MacOS:
+### macOS:
 
 ```shell
 brew install ffmpeg gstreamer python3
@@ -59,7 +59,7 @@ In case of issues with compilation of membrane_h264_ffmpeg_plugin, enter:
 mix deps.update bundlex
 ```
 
-and then install pkg-config (MacOS):
+and then install pkg-config (macOS):
 
 ```shell
 brew install pkg-config

--- a/rtp_to_hls/README.md
+++ b/rtp_to_hls/README.md
@@ -15,7 +15,7 @@ Below is the instruction for the installation of required dependencies and how t
 
 ### Prerequisites
 
-You must have following packages installed on your system:
+You must have the following packages installed on your system:
 
 - FFmpeg 4.\*
 - GStreamer > 1.0 to provide RTP streams
@@ -44,7 +44,7 @@ mix deps.get
 
 You may be asked to install `Hex` and then `rebar3`.
 
-> In case of issues with compilation of membrane_h264_ffmpeg_plugin, enter:
+> In case of issues with the compilation of membrane_h264_ffmpeg_plugin, enter:
 >
 > ```shell
 > mix deps.update bundlex
@@ -62,10 +62,10 @@ Finally, you can run the demo with:
 mix run --no-halt
 ```
 
-Server will start listening for UDP connections by default on port 5000.
+The server will start listening for UDP connections by default on port 5000.
 
-After that you can start sending any H264 video and AAC audio stream
-via RTP. Below you can see an example how to generate sample streams
+After that, you can start sending any H264 video and AAC audio stream
+via RTP. Below you can see an example of how to generate sample streams
 with GStreamer.
 
 ```shell
@@ -73,15 +73,15 @@ gst-launch-1.0 -v audiotestsrc ! audio/x-raw,rate=44100 ! faac ! rtpmp4gpay  pt=
     videotestsrc ! video/x-raw,format=I420 ! x264enc key-int-max=10 tune=zerolatency ! rtph264pay pt=96 ! udpsink host=127.0.0.1 port=5000
 ```
 
-HLS header and segment files will be created in `output` directory along with playlist files.
+HLS header and segment files will be created in the `output` directory along with playlist files.
 
-To play the HLS stream you need to serve the content of `output` dir, e.g. by running:
+To play the HLS stream you need to serve the content of the `output` dir, e.g. by running:
 
 ```shell
 cd output && python3 -m http.server 8000
 ```
 
-Then, you can open the url `http://localhost:8000/index.m3u8` in some player, e.g. `ffplay` or `vlc`
+Then, you can open the URL `http://localhost:8000/index.m3u8` in some players, e.g. `ffplay` or `vlc`
 
 ```shell
 ffplay http://localhost:8000/index.m3u8
@@ -96,7 +96,7 @@ ffplay http://localhost:8000/index.m3u8
 
 ### Prerequisites
 
-You must have following packages installed on your system:
+You must have the following packages installed on your system:
 
 - FFmpeg 4.\*
 - GStreamer > 1.0 to provide RTP streams
@@ -133,7 +133,7 @@ You may be asked to install `Hex` and then `rebar3`.
 > sudo apt-get update
 > ```
 
-> In case of issues with compilation of membrane_h264_ffmpeg_plugin, enter:
+> In case of issues with the compilation of membrane_h264_ffmpeg_plugin, enter:
 >
 > ```shell
 > mix deps.update bundlex
@@ -145,10 +145,10 @@ Finally, you can run the demo with:
 mix run --no-halt
 ```
 
-Server will start listening for UDP connections by default on port 5000.
+The server will start listening for UDP connections by default on port 5000.
 
-After that you can start sending any H264 video and AAC audio stream
-via RTP. Below you can see an example how to generate sample streams
+After that, you can start sending any H264 video and AAC audio stream
+via RTP. Below you can see an example of how to generate sample streams
 with GStreamer.
 
 ```shell
@@ -156,15 +156,15 @@ gst-launch-1.0 -v audiotestsrc ! audio/x-raw,rate=44100 ! faac ! rtpmp4gpay  pt=
     videotestsrc ! video/x-raw,format=I420 ! x264enc key-int-max=10 tune=zerolatency ! rtph264pay pt=96 ! udpsink host=127.0.0.1 port=5000
 ```
 
-HLS header and segment files will be created in `output` directory along with playlist files.
+HLS header and segment files will be created in the `output` directory along with playlist files.
 
-To play the HLS stream you need to serve the content of `output` dir, e.g. by running:
+To play the HLS stream you need to serve the content of the `output` dir, e.g. by running:
 
 ```shell
 cd output && python3 -m http.server 8000
 ```
 
-Then, you can open the url `http://localhost:8000/index.m3u8` in some player, e.g. `ffplay` or `vlc`
+Then, you can open the URL `http://localhost:8000/index.m3u8` in some players, e.g. `ffplay` or `vlc`
 
 ```shell
 ffplay http://localhost:8000/index.m3u8

--- a/rtp_to_hls/README.md
+++ b/rtp_to_hls/README.md
@@ -81,7 +81,7 @@ To play the HLS stream you need to serve the content of the `output` dir, e.g. b
 cd output && python3 -m http.server 8000
 ```
 
-Then, you can open the URL `http://localhost:8000/index.m3u8` in some players, e.g. `ffplay` or `vlc`
+Then, you can open the URL `http://localhost:8000/index.m3u8` in some player, e.g. `ffplay` or `vlc`
 
 ```shell
 ffplay http://localhost:8000/index.m3u8
@@ -164,7 +164,7 @@ To play the HLS stream you need to serve the content of the `output` dir, e.g. b
 cd output && python3 -m http.server 8000
 ```
 
-Then, you can open the URL `http://localhost:8000/index.m3u8` in some players, e.g. `ffplay` or `vlc`
+Then, you can open the URL `http://localhost:8000/index.m3u8` in some player, e.g. `ffplay` or `vlc`
 
 ```shell
 ffplay http://localhost:8000/index.m3u8

--- a/rtp_to_hls/README.md
+++ b/rtp_to_hls/README.md
@@ -56,7 +56,7 @@ You may be asked to install `Hex` and then `rebar3`.
 > brew install pkg-config
 > ```
 
-Finally ,you can run the demo with:
+Finally, you can run the demo with:
 
 ```shell
 mix run --no-halt
@@ -139,7 +139,7 @@ You may be asked to install `Hex` and then `rebar3`.
 > mix deps.update bundlex
 > ```
 
-Finally ,you can run the demo with:
+Finally, you can run the demo with:
 
 ```shell
 mix run --no-halt

--- a/rtp_to_hls/README.md
+++ b/rtp_to_hls/README.md
@@ -4,34 +4,30 @@ This project demonstrates handling RTP streams and converting them to HLS stream
 
 The whole idea has been described in [this blog post](https://blog.swmansion.com/live-video-streaming-in-elixir-made-simple-with-membrane-fc5b2083982d).
 
-## Prerequisites
+## Prerequisites and running the demo
+
+Below is the instruction for the installation of required dependencies and how to run this demo on various operating systems:
+
+<details>
+<summary>
+<b>macOS</b>
+</summary>
+
+### Prerequisites
 
 You must have following packages installed on your system:
 
 - FFmpeg 4.\*
-
-### Additional tools used by the following guide
-
 - GStreamer > 1.0 to provide RTP streams
 - python3 for running simple Web Server
-
-### macOS:
 
 ```shell
 brew install ffmpeg gstreamer python3
 ```
 
-### Ubuntu:
-
-```shell
-apt install ffmpeg gstreamer python3
-```
-
 Furthermore, make sure you have `Elixir` and `Erlang` installed on your machine. For installation details, see: https://elixir-lang.org/install.html
 
-On Ubuntu, we recommend installation through `asdf`, see: https://asdf-vm.com/guide/getting-started.html
-
-## Run the demo
+### Run the demo
 
 To run the demo, clone the membrane_demo repository and checkout to the demo directory:
 
@@ -47,23 +43,18 @@ mix deps.get
 ```
 
 You may be asked to install `Hex` and then `rebar3`.
-In case of installation issues with Hex on Ubuntu, try updating the system packages first by entering the command:
 
-```shell
-sudo apt-get update
-```
-
-In case of issues with compilation of membrane_h264_ffmpeg_plugin, enter:
-
-```shell
-mix deps.update bundlex
-```
-
-and then install pkg-config (macOS):
-
-```shell
-brew install pkg-config
-```
+> In case of issues with compilation of membrane_h264_ffmpeg_plugin, enter:
+>
+> ```shell
+> mix deps.update bundlex
+> ```
+>
+> and then install pkg-config:
+>
+> ```shell
+> brew install pkg-config
+> ```
 
 Finally ,you can run the demo with:
 
@@ -95,6 +86,91 @@ Then, you can open the url `http://localhost:8000/index.m3u8` in some player, e.
 ```shell
 ffplay http://localhost:8000/index.m3u8
 ```
+
+</details>
+
+<details>
+<summary>
+<b>Ubuntu</b>
+</summary>
+
+### Prerequisites
+
+You must have following packages installed on your system:
+
+- FFmpeg 4.\*
+- GStreamer > 1.0 to provide RTP streams
+- python3 for running simple Web Server
+
+```shell
+apt install ffmpeg gstreamer python3
+```
+
+Furthermore, make sure you have `Elixir` and `Erlang` installed on your machine. For installation details, see: https://elixir-lang.org/install.html
+
+On Ubuntu, we recommend installation through `asdf`, see: https://asdf-vm.com/guide/getting-started.html
+
+### Run the demo
+
+To run the demo, clone the membrane_demo repository and checkout to the demo directory:
+
+```shell
+git clone https://github.com/membraneframework/membrane_demo
+cd membrane_demo/rtp_to_hls
+```
+
+Then you need to download the dependencies of the mix project:
+
+```shell
+mix deps.get
+```
+
+You may be asked to install `Hex` and then `rebar3`.
+
+> In case of installation issues with Hex on Ubuntu, try updating the system packages first by entering the command:
+>
+> ```shell
+> sudo apt-get update
+> ```
+
+> In case of issues with compilation of membrane_h264_ffmpeg_plugin, enter:
+>
+> ```shell
+> mix deps.update bundlex
+> ```
+
+Finally ,you can run the demo with:
+
+```shell
+mix run --no-halt
+```
+
+Server will start listening for UDP connections by default on port 5000.
+
+After that you can start sending any H264 video and AAC audio stream
+via RTP. Below you can see an example how to generate sample streams
+with GStreamer.
+
+```shell
+gst-launch-1.0 -v audiotestsrc ! audio/x-raw,rate=44100 ! faac ! rtpmp4gpay  pt=127 ! udpsink host=127.0.0.1 port=5000 \
+    videotestsrc ! video/x-raw,format=I420 ! x264enc key-int-max=10 tune=zerolatency ! rtph264pay pt=96 ! udpsink host=127.0.0.1 port=5000
+```
+
+HLS header and segment files will be created in `output` directory along with playlist files.
+
+To play the HLS stream you need to serve the content of `output` dir, e.g. by running:
+
+```shell
+cd output && python3 -m http.server 8000
+```
+
+Then, you can open the url `http://localhost:8000/index.m3u8` in some player, e.g. `ffplay` or `vlc`
+
+```shell
+ffplay http://localhost:8000/index.m3u8
+```
+
+</details>
 
 ## Copyright and License
 

--- a/rtp_to_hls/README.md
+++ b/rtp_to_hls/README.md
@@ -15,9 +15,58 @@ You must have following packages installed on your system:
 - GStreamer > 1.0 to provide RTP streams
 - python3 for running simple Web Server
 
+### MacOS:
+
+```
+brew install ffmpeg gstreamer python3
+```
+
+### Ubuntu:
+
+```
+apt install ffmpeg gstreamer python3
+```
+
+Furthermore, make sure you have `Elixir` and `Erlang` installed on your machine. For installation details, see: https://elixir-lang.org/install.html
+
+On Ubuntu, we recommend installation through asdf, see: https://asdf-vm.com/guide/getting-started.html
+
 ## Run the demo
 
-Run the project with:
+To run the demo, clone the membrane_demo repository and checkout to the demo directory:
+
+```
+git clone https://github.com/membraneframework/membrane_demo
+cd membrane_demo/rtp_to_hls
+```
+
+Then you need to download the dependencies of the mix project:
+
+```
+mix deps.get
+```
+
+Then you may be asked to install `Hex` and then `rebar3`.
+
+In case of installation issues with Hex on Ubuntu, try updating the system packages first by entering the command:
+
+```shell
+sudo apt-get update
+```
+
+In case of issue with compilation of membrane_h264_ffmpeg_plugin, enter:
+
+```shell
+mix deps.update bundlex
+```
+
+and then install pkg-config (MacOS):
+
+```
+brew install pkg-config
+```
+
+Finally ,you can run the demo with:
 
 ```bash
 mix run --no-halt

--- a/rtp_to_hls/README.md
+++ b/rtp_to_hls/README.md
@@ -8,7 +8,7 @@ The whole idea has been described in [this blog post](https://blog.swmansion.com
 
 You must have following packages installed on your system:
 
-- ffmpeg 4.\*
+- FFmpeg 4.\*
 
 ### Additional tools used by the following guide
 
@@ -17,44 +17,43 @@ You must have following packages installed on your system:
 
 ### MacOS:
 
-```
+```shell
 brew install ffmpeg gstreamer python3
 ```
 
 ### Ubuntu:
 
-```
+```shell
 apt install ffmpeg gstreamer python3
 ```
 
 Furthermore, make sure you have `Elixir` and `Erlang` installed on your machine. For installation details, see: https://elixir-lang.org/install.html
 
-On Ubuntu, we recommend installation through asdf, see: https://asdf-vm.com/guide/getting-started.html
+On Ubuntu, we recommend installation through `asdf`, see: https://asdf-vm.com/guide/getting-started.html
 
 ## Run the demo
 
 To run the demo, clone the membrane_demo repository and checkout to the demo directory:
 
-```
+```shell
 git clone https://github.com/membraneframework/membrane_demo
 cd membrane_demo/rtp_to_hls
 ```
 
 Then you need to download the dependencies of the mix project:
 
-```
+```shell
 mix deps.get
 ```
 
-Then you may be asked to install `Hex` and then `rebar3`.
-
+You may be asked to install `Hex` and then `rebar3`.
 In case of installation issues with Hex on Ubuntu, try updating the system packages first by entering the command:
 
 ```shell
 sudo apt-get update
 ```
 
-In case of issue with compilation of membrane_h264_ffmpeg_plugin, enter:
+In case of issues with compilation of membrane_h264_ffmpeg_plugin, enter:
 
 ```shell
 mix deps.update bundlex
@@ -62,13 +61,13 @@ mix deps.update bundlex
 
 and then install pkg-config (MacOS):
 
-```
+```shell
 brew install pkg-config
 ```
 
 Finally ,you can run the demo with:
 
-```bash
+```shell
 mix run --no-halt
 ```
 
@@ -78,7 +77,7 @@ After that you can start sending any H264 video and AAC audio stream
 via RTP. Below you can see an example how to generate sample streams
 with GStreamer.
 
-```bash
+```shell
 gst-launch-1.0 -v audiotestsrc ! audio/x-raw,rate=44100 ! faac ! rtpmp4gpay  pt=127 ! udpsink host=127.0.0.1 port=5000 \
     videotestsrc ! video/x-raw,format=I420 ! x264enc key-int-max=10 tune=zerolatency ! rtph264pay pt=96 ! udpsink host=127.0.0.1 port=5000
 ```
@@ -87,13 +86,13 @@ HLS header and segment files will be created in `output` directory along with pl
 
 To play the HLS stream you need to serve the content of `output` dir, e.g. by running:
 
-```bash
+```shell
 cd output && python3 -m http.server 8000
 ```
 
 Then, you can open the url `http://localhost:8000/index.m3u8` in some player, e.g. `ffplay` or `vlc`
 
-```bash
+```shell
 ffplay http://localhost:8000/index.m3u8
 ```
 

--- a/rtsp_to_hls/.gitignore
+++ b/rtsp_to_hls/.gitignore
@@ -30,5 +30,5 @@ hls_proxy_api-*.tar
 *.m4s
 *.mp4
 
-# MacOS
+# macOS
 .DS_Store

--- a/rtsp_to_hls/README.md
+++ b/rtsp_to_hls/README.md
@@ -106,8 +106,6 @@ In order to run this demo you have to run it on a machine with a publicly visibl
 Make sure you have [FFmpeg](https://www.ffmpeg.org/) installed on your machine - you are going to
 use it to play the stream. We advise to use FFmpeg 5.0 or newer.
 
-Ubuntu
-
 ```shell
 apt install ffmpeg
 ```

--- a/rtsp_to_hls/README.md
+++ b/rtsp_to_hls/README.md
@@ -17,30 +17,30 @@ The internal architecture of an application is presented below:
 
 In order to run this demo you have to run it on a machine with a publicly visible ip address.
 
-Make sure you have [ffmpeg](https://www.ffmpeg.org/) installed on your machine - you are going to
-use it to play the stream. We advise to use ffmpeg 5.0 or newer.
+Make sure you have [FFmpeg](https://www.ffmpeg.org/) installed on your machine - you are going to
+use it to play the stream. We advise to use FFmpeg 5.0 or newer.
 
 Ubuntu
 
-```console
+```shell
 apt install ffmpeg
 ```
 
 Mac OS
 
-```console
+```shell
 brew install ffmpeg
 ```
 
 Furthermore, make sure you have Elixir installed on your machine. For installation details, see: https://elixir-lang.org/install.html
 
-On Ubuntu, we recommend installation through asdf, see: https://asdf-vm.com/guide/getting-started.html
+On Ubuntu, we recommend installation through `asdf`, see: https://asdf-vm.com/guide/getting-started.html
 
 ## Running the demo
 
 To run the demo, clone the `membrane_demo` repository and checkout to the demo directory:
 
-```console
+```shell
 git clone https://github.com/membraneframework/membrane_demo
 cd membrane_demo/rtsp_to_hls
 ```
@@ -59,19 +59,18 @@ By default we use our sample RTSP stream at rtsp.membrane.work.
 
 Then you need to download the dependencies of the mix project:
 
-```console
+```shell
 mix deps.get
 ```
 
-Then you may be asked to install `Hex` and then `rebar3`.
-
+You may be asked to install `Hex` and then `rebar3`.
 In case of installation issues with Hex on Ubuntu, try updating the system packages first by entering the command:
 
 ```shell
 sudo apt-get update
 ```
 
-In case of issue with compilation of membrane_h264_ffmpeg_plugin, enter:
+In case of issues with compilation of membrane_h264_ffmpeg_plugin, enter:
 
 ```shell
 mix deps.update bundlex
@@ -79,25 +78,25 @@ mix deps.update bundlex
 
 and then install pkg-config (MacOS):
 
-```
+```shell
 brew install pkg-config
 ```
 
 Finally, you can start the pipeline by running:
 
-```console
+```shell
 mix run --no-halt
 ```
 
 After a moment the pipeline will start generating HLS output files. In order to watch the stream we need to serve those files, e.g. by using python http server:
 
-```console
+```shell
 python3 -m http.server 8000
 ```
 
 You can then play the stream using ffmpeg:
 
-```console
+```shell
 ffplay http://localhost:8000/hls_output/index.m3u8
 ```
 

--- a/rtsp_to_hls/README.md
+++ b/rtsp_to_hls/README.md
@@ -3,6 +3,7 @@
 This demo demonstrates receiving RTSP stream and converting it to HLS stream.
 
 ## Components
+
 The project consists of 2 parts:
 
 - The pipeline, which converts the RTP stream to HLS
@@ -14,33 +15,28 @@ The internal architecture of an application is presented below:
 
 ## Prerequisites
 
-1. In order to run this demo you have to run it on a machine with a publicly visible ip address.
+In order to run this demo you have to run it on a machine with a publicly visible ip address.
 
-2. Make sure you have [ffmpeg](https://www.ffmpeg.org/) installed on your machine - you are going to
+Make sure you have [ffmpeg](https://www.ffmpeg.org/) installed on your machine - you are going to
 use it to play the stream. We advise to use ffmpeg 5.0 or newer.
 
 Ubuntu
+
 ```console
 apt install ffmpeg
 ```
 
 Mac OS
+
 ```console
 brew install ffmpeg
 ```
 
-3. Furthermore, make sure you have Elixir installed on your machine. For installation details, see: https://elixir-lang.org/install.html
+Furthermore, make sure you have Elixir installed on your machine. For installation details, see: https://elixir-lang.org/install.html
+
+On Ubuntu, we recommend installation through asdf, see: https://asdf-vm.com/guide/getting-started.html
 
 ## Running the demo
-You can configure the parameters for the converter in the `Application` module:
-##### lib/application.ex
-```elixir
-@rtsp_stream_url "rtsp://rtsp.membrane.work:554/testsrc.264"
-@output_path "hls_output"
-@rtp_port 20000
-```
-By default we use our sample RTSP stream at rtsp.membrane.work.
-
 
 To run the demo, clone the `membrane_demo` repository and checkout to the demo directory:
 
@@ -49,12 +45,46 @@ git clone https://github.com/membraneframework/membrane_demo
 cd membrane_demo/rtsp_to_hls
 ```
 
+You can configure the parameters for the converter in the `Application` module:
+
+##### lib/application.ex
+
+```elixir
+@rtsp_stream_url "rtsp://rtsp.membrane.work:554/testsrc.264"
+@output_path "hls_output"
+@rtp_port 20000
+```
+
+By default we use our sample RTSP stream at rtsp.membrane.work.
+
 Then you need to download the dependencies of the mix project:
+
 ```console
 mix deps.get
 ```
 
-You can start the pipeline by running:
+Then you may be asked to install `Hex` and then `rebar3`.
+
+In case of installation issues with Hex on Ubuntu, try updating the system packages first by entering the command:
+
+```shell
+sudo apt-get update
+```
+
+In case of issue with compilation of membrane_h264_ffmpeg_plugin, enter:
+
+```shell
+mix deps.update bundlex
+```
+
+and then install pkg-config (MacOS):
+
+```
+brew install pkg-config
+```
+
+Finally, you can start the pipeline by running:
+
 ```console
 mix run --no-halt
 ```
@@ -68,7 +98,7 @@ python3 -m http.server 8000
 You can then play the stream using ffmpeg:
 
 ```console
-ffplay http://YOUR_SERVER_IP/hls_output/index.m3u8
+ffplay http://localhost:8000/hls_output/index.m3u8
 ```
 
 ## Copyright and License

--- a/rtsp_to_hls/README.md
+++ b/rtsp_to_hls/README.md
@@ -76,7 +76,7 @@ In case of issues with compilation of membrane_h264_ffmpeg_plugin, enter:
 mix deps.update bundlex
 ```
 
-and then install pkg-config (MacOS):
+and then install pkg-config (macOS):
 
 ```shell
 brew install pkg-config

--- a/rtsp_to_hls/README.md
+++ b/rtsp_to_hls/README.md
@@ -13,20 +13,21 @@ The internal architecture of an application is presented below:
 
 ![Application scheme](doc_assets/RTSP_to_HLS_pipeline.png)
 
-## Prerequisites
+## Prerequisites and running the demo
+
+Below is the instruction for the installation of required dependencies and how to run this demo on various operating systems:
+
+<details>
+<summary>
+<b>macOS</b>
+</summary>
+
+### Prerequisites
 
 In order to run this demo you have to run it on a machine with a publicly visible ip address.
 
 Make sure you have [FFmpeg](https://www.ffmpeg.org/) installed on your machine - you are going to
 use it to play the stream. We advise to use FFmpeg 5.0 or newer.
-
-Ubuntu
-
-```shell
-apt install ffmpeg
-```
-
-Mac OS
 
 ```shell
 brew install ffmpeg
@@ -34,9 +35,7 @@ brew install ffmpeg
 
 Furthermore, make sure you have Elixir installed on your machine. For installation details, see: https://elixir-lang.org/install.html
 
-On Ubuntu, we recommend installation through `asdf`, see: https://asdf-vm.com/guide/getting-started.html
-
-## Running the demo
+### Running the demo
 
 To run the demo, clone the `membrane_demo` repository and checkout to the demo directory:
 
@@ -64,23 +63,18 @@ mix deps.get
 ```
 
 You may be asked to install `Hex` and then `rebar3`.
-In case of installation issues with Hex on Ubuntu, try updating the system packages first by entering the command:
 
-```shell
-sudo apt-get update
-```
-
-In case of issues with compilation of membrane_h264_ffmpeg_plugin, enter:
-
-```shell
-mix deps.update bundlex
-```
-
-and then install pkg-config (macOS):
-
-```shell
-brew install pkg-config
-```
+> In case of issues with compilation of membrane_h264_ffmpeg_plugin, enter:
+>
+> ```shell
+> mix deps.update bundlex
+> ```
+>
+> and then install pkg-config:
+>
+> ```shell
+> brew install pkg-config
+> ```
 
 Finally, you can start the pipeline by running:
 
@@ -99,6 +93,89 @@ You can then play the stream using ffmpeg:
 ```shell
 ffplay http://localhost:8000/hls_output/index.m3u8
 ```
+
+</details>
+
+<details>
+<summary>
+<b>Ubuntu</b>
+</summary>
+
+In order to run this demo you have to run it on a machine with a publicly visible ip address.
+
+Make sure you have [FFmpeg](https://www.ffmpeg.org/) installed on your machine - you are going to
+use it to play the stream. We advise to use FFmpeg 5.0 or newer.
+
+Ubuntu
+
+```shell
+apt install ffmpeg
+```
+
+Furthermore, make sure you have Elixir installed on your machine. For installation details, see: https://elixir-lang.org/install.html
+
+On Ubuntu, we recommend installation through `asdf`, see: https://asdf-vm.com/guide/getting-started.html
+
+### Running the demo
+
+To run the demo, clone the `membrane_demo` repository and checkout to the demo directory:
+
+```shell
+git clone https://github.com/membraneframework/membrane_demo
+cd membrane_demo/rtsp_to_hls
+```
+
+You can configure the parameters for the converter in the `Application` module:
+
+##### lib/application.ex
+
+```elixir
+@rtsp_stream_url "rtsp://rtsp.membrane.work:554/testsrc.264"
+@output_path "hls_output"
+@rtp_port 20000
+```
+
+By default we use our sample RTSP stream at rtsp.membrane.work.
+
+Then you need to download the dependencies of the mix project:
+
+```shell
+mix deps.get
+```
+
+You may be asked to install `Hex` and then `rebar3`.
+
+> In case of installation issues with Hex on Ubuntu, try updating the system packages first by entering the command:
+>
+> ```shell
+> sudo apt-get update
+> ```
+
+> In case of issues with compilation of membrane_h264_ffmpeg_plugin, enter:
+>
+> ```shell
+> mix deps.update bundlex
+> ```
+
+Finally, you can start the pipeline by running:
+
+```shell
+mix run --no-halt
+```
+
+After a moment the pipeline will start generating HLS output files. In order to watch the stream we need to serve those files, e.g. by using python http server:
+
+```shell
+python3 -m http.server 8000
+```
+
+You can then play the stream using ffmpeg:
+
+```shell
+ffplay http://localhost:8000/hls_output/index.m3u8
+```
+
+</details>
 
 ## Copyright and License
 

--- a/rtsp_to_hls/README.md
+++ b/rtsp_to_hls/README.md
@@ -1,13 +1,13 @@
 # RTSP to HLS converter demo
 
-This demo demonstrates receiving RTSP stream and converting it to HLS stream.
+This demo demonstrates receiving the RTSP stream and converting it to the HLS stream.
 
 ## Components
 
 The project consists of 2 parts:
 
 - The pipeline, which converts the RTP stream to HLS
-- Connection Manager, which is started by the pipeline and is responsible for establishing RTSP connection
+- Connection Manager, which is started by the pipeline and is responsible for establishing the RTSP connection
 
 The internal architecture of an application is presented below:
 
@@ -24,10 +24,10 @@ Below is the instruction for the installation of required dependencies and how t
 
 ### Prerequisites
 
-In order to run this demo you have to run it on a machine with a publicly visible ip address.
+To run this demo you have to run it on a machine with a publicly visible IP address.
 
 Make sure you have [FFmpeg](https://www.ffmpeg.org/) installed on your machine - you are going to
-use it to play the stream. We advise to use FFmpeg 5.0 or newer.
+use it to play the stream. We advise you to use FFmpeg 5.0 or newer.
 
 ```shell
 brew install ffmpeg
@@ -54,7 +54,7 @@ You can configure the parameters for the converter in the `Application` module:
 @rtp_port 20000
 ```
 
-By default we use our sample RTSP stream at rtsp.membrane.work.
+By default, we use our sample RTSP stream at rtsp.membrane.work.
 
 Then you need to download the dependencies of the mix project:
 
@@ -64,7 +64,7 @@ mix deps.get
 
 You may be asked to install `Hex` and then `rebar3`.
 
-> In case of issues with compilation of membrane_h264_ffmpeg_plugin, enter:
+> In case of issues with the compilation of membrane_h264_ffmpeg_plugin, enter:
 >
 > ```shell
 > mix deps.update bundlex
@@ -82,7 +82,7 @@ Finally, you can start the pipeline by running:
 mix run --no-halt
 ```
 
-After a moment the pipeline will start generating HLS output files. In order to watch the stream we need to serve those files, e.g. by using python http server:
+After a moment the pipeline will start generating HLS output files. To watch the stream we need to serve those files, e.g. by using python HTTP server:
 
 ```shell
 python3 -m http.server 8000
@@ -101,10 +101,10 @@ ffplay http://localhost:8000/hls_output/index.m3u8
 <b>Ubuntu</b>
 </summary>
 
-In order to run this demo you have to run it on a machine with a publicly visible ip address.
+To run this demo you have to run it on a machine with a publicly visible IP address.
 
 Make sure you have [FFmpeg](https://www.ffmpeg.org/) installed on your machine - you are going to
-use it to play the stream. We advise to use FFmpeg 5.0 or newer.
+use it to play the stream. We advise you to use FFmpeg 5.0 or newer.
 
 ```shell
 apt install ffmpeg
@@ -133,7 +133,7 @@ You can configure the parameters for the converter in the `Application` module:
 @rtp_port 20000
 ```
 
-By default we use our sample RTSP stream at rtsp.membrane.work.
+By default, we use our sample RTSP stream at rtsp.membrane.work.
 
 Then you need to download the dependencies of the mix project:
 
@@ -149,7 +149,7 @@ You may be asked to install `Hex` and then `rebar3`.
 > sudo apt-get update
 > ```
 
-> In case of issues with compilation of membrane_h264_ffmpeg_plugin, enter:
+> In case of issues with the compilation of membrane_h264_ffmpeg_plugin, enter:
 >
 > ```shell
 > mix deps.update bundlex
@@ -161,7 +161,7 @@ Finally, you can start the pipeline by running:
 mix run --no-halt
 ```
 
-After a moment the pipeline will start generating HLS output files. In order to watch the stream we need to serve those files, e.g. by using python http server:
+After a moment the pipeline will start generating HLS output files. To watch the stream we need to serve those files, e.g. by using python HTTP server:
 
 ```shell
 python3 -m http.server 8000

--- a/simple_element/README.md
+++ b/simple_element/README.md
@@ -4,26 +4,52 @@ This demo shows how to create a simple Membrane element and plug it into a pipel
 
 ## Prerequisites
 
-1. Make sure you have following libraries installed on your OS:
-   * clang-format, 
-   * portaudio19-dev, 
-   * ffmpeg, 
-   * libavutil-dev, 
-   * libswresample-dev, 
-   * libmad0-dev
-   
-    One-liner for Ubuntu
-    ```bash
-    apt install clang-format portaudio19-dev ffmpeg libavutil-dev libswresample-dev libmad0-dev
-    ```
-    One-liner for MacOS
-    ```bash
-    brew install clang-format portaudio ffmpeg libmad pkg-config
-    ```
-1. Make sure you have Elixir installed on your machine. See: https://elixir-lang.org/install.html
-1. Fetch the required dependencies by running `mix deps.get`
+Make sure you have following libraries installed on your OS:
 
-## Run the demo
+- clang-format,
+- portaudio19-dev,
+- FFmpeg 4.\*,
+- libavutil-dev,
+- libswresample-dev,
+- libmad0-dev
+
+### Ubuntu
+
+```shell
+apt install clang-format portaudio19-dev ffmpeg libavutil-dev libswresample-dev libmad0-dev
+```
+
+### macOS
+
+```shell
+brew install clang-format portaudio ffmpeg libmad pkg-config
+```
+
+Furthermore, make sure you have Elixir installed on your machine. For installation details, see: https://elixir-lang.org/install.html
+
+On Ubuntu, we recommend installation through `asdf`, see: https://asdf-vm.com/guide/getting-started.html
+
+## Running the demo
+
+To run the demo, clone the `membrane_demo` repository and checkout to the demo directory:
+
+```shell
+git clone https://github.com/membraneframework/membrane_demo
+cd membrane_demo/simple_element
+```
+
+Then you need to download the dependencies of the mix project:
+
+```shell
+mix deps.get
+```
+
+You may be asked to install `Hex` and then `rebar3`.
+In case of installation issues with Hex on Ubuntu, try updating the system packages first by entering the command:
+
+```shell
+sudo apt-get update
+```
 
 To start the demo pipeline run `mix run --no-halt run.exs` or type the following commands into an IEx shell (started by `iex -S mix`):
 

--- a/simple_element/README.md
+++ b/simple_element/README.md
@@ -2,7 +2,16 @@
 
 This demo shows how to create a simple Membrane element and plug it into a pipeline.
 
-## Prerequisites
+## Prerequisites and running the demo
+
+Below is the instruction for the installation of required dependencies and how to run this demo on various operating systems:
+
+<details>
+<summary>
+<b>macOS</b>
+</summary>
+
+### Prerequisites
 
 Make sure you have following libraries installed on your OS:
 
@@ -13,23 +22,13 @@ Make sure you have following libraries installed on your OS:
 - libswresample-dev,
 - libmad0-dev
 
-### Ubuntu
-
-```shell
-apt install clang-format portaudio19-dev ffmpeg libavutil-dev libswresample-dev libmad0-dev
-```
-
-### macOS
-
 ```shell
 brew install clang-format portaudio ffmpeg libmad pkg-config
 ```
 
 Furthermore, make sure you have Elixir installed on your machine. For installation details, see: https://elixir-lang.org/install.html
 
-On Ubuntu, we recommend installation through `asdf`, see: https://asdf-vm.com/guide/getting-started.html
-
-## Running the demo
+### Running the demo
 
 To run the demo, clone the `membrane_demo` repository and checkout to the demo directory:
 
@@ -45,11 +44,6 @@ mix deps.get
 ```
 
 You may be asked to install `Hex` and then `rebar3`.
-In case of installation issues with Hex on Ubuntu, try updating the system packages first by entering the command:
-
-```shell
-sudo apt-get update
-```
 
 To start the demo pipeline run `mix run --no-halt run.exs` or type the following commands into an IEx shell (started by `iex -S mix`):
 
@@ -59,6 +53,66 @@ alias Membrane.Demo.SimpleElement.Pipeline
 ```
 
 You should hear the audio sample playing and see the number of buffers processed being periodically printed to the console.
+
+</details>
+
+<details>
+<summary>
+<b>Ubuntu</b>
+</summary>
+
+### Prerequisites
+
+Make sure you have following libraries installed on your OS:
+
+- clang-format,
+- portaudio19-dev,
+- FFmpeg 4.\*,
+- libavutil-dev,
+- libswresample-dev,
+- libmad0-dev
+
+```shell
+apt install clang-format portaudio19-dev ffmpeg libavutil-dev libswresample-dev libmad0-dev
+```
+
+Furthermore, make sure you have Elixir installed on your machine. For installation details, see: https://elixir-lang.org/install.html
+
+On Ubuntu, we recommend installation through `asdf`, see: https://asdf-vm.com/guide/getting-started.html
+
+### Running the demo
+
+To run the demo, clone the `membrane_demo` repository and checkout to the demo directory:
+
+```shell
+git clone https://github.com/membraneframework/membrane_demo
+cd membrane_demo/simple_element
+```
+
+Then you need to download the dependencies of the mix project:
+
+```shell
+mix deps.get
+```
+
+You may be asked to install `Hex` and then `rebar3`.
+
+> In case of installation issues with Hex on Ubuntu, try updating the system packages first by entering the command:
+>
+> ```shell
+> sudo apt-get update
+> ```
+
+To start the demo pipeline run `mix run --no-halt run.exs` or type the following commands into an IEx shell (started by `iex -S mix`):
+
+```elixir
+alias Membrane.Demo.SimpleElement.Pipeline
+{:ok, pid} = Pipeline.start_link("sample.mp3")
+```
+
+You should hear the audio sample playing and see the number of buffers processed being periodically printed to the console.
+
+</details>
 
 ## How it works
 

--- a/simple_element/README.md
+++ b/simple_element/README.md
@@ -13,7 +13,7 @@ Below is the instruction for the installation of required dependencies and how t
 
 ### Prerequisites
 
-Make sure you have following libraries installed on your OS:
+Make sure you have the following libraries installed on your OS:
 
 - clang-format,
 - portaudio19-dev,
@@ -63,7 +63,7 @@ You should hear the audio sample playing and see the number of buffers processed
 
 ### Prerequisites
 
-Make sure you have following libraries installed on your OS:
+Make sure you have the following libraries installed on your OS:
 
 - clang-format,
 - portaudio19-dev,
@@ -116,7 +116,7 @@ You should hear the audio sample playing and see the number of buffers processed
 
 ## How it works
 
-The pipeline takes sample mp3 file, decodes it and plays the audio.
+The pipeline takes a sample mp3 file, decodes it, and plays the audio.
 The simple `counter` element is responsible for counting the number of buffers
 passing through it and periodically prints the number of buffers processed to the console.
 
@@ -124,7 +124,7 @@ The element is plugged in just before the audio player element in the pipeline.
 
 ## Sample License
 
-Sample is provided under Creative Commons. Song is called Swan Song by [Paper Navy](https://papernavy.bandcamp.com/album/all-grown-up).
+The sample is provided under Creative Commons. Song is called Swan Song by [Paper Navy](https://papernavy.bandcamp.com/album/all-grown-up).
 
 ## Copyright and License
 

--- a/simple_pipeline/README.md
+++ b/simple_pipeline/README.md
@@ -13,7 +13,7 @@ Below is the instruction for the installation of required dependencies and how t
 
 ### Prerequisites
 
-Make sure you have following libraries installed on your OS:
+Make sure you have the following libraries installed on your OS:
 
 - clang-format,
 - portaudio19-dev,
@@ -60,7 +60,7 @@ To start the demo pipeline run `mix run --no-halt run.exs` or type the following
 
 ### Prerequisites
 
-Make sure you have following libraries installed on your OS:
+Make sure you have the following libraries installed on your OS:
 
 - clang-format,
 - portaudio19-dev,
@@ -110,7 +110,7 @@ To start the demo pipeline run `mix run --no-halt run.exs` or type the following
 
 ## Sample License
 
-Sample is provided under Creative Commons. Song is called Swan Song by [Paper Navy](https://papernavy.bandcamp.com/album/all-grown-up).
+The sample is provided under Creative Commons. Song is called Swan Song by [Paper Navy](https://papernavy.bandcamp.com/album/all-grown-up).
 
 ## Copyright and License
 

--- a/simple_pipeline/README.md
+++ b/simple_pipeline/README.md
@@ -2,7 +2,16 @@
 
 This demo shows how to create a pipeline that plays an mp3 file.
 
-## Prerequisites
+## Prerequisites and running the demo
+
+Below is the instruction for the installation of required dependencies and how to run this demo on various operating systems:
+
+<details>
+<summary>
+<b>macOS</b>
+</summary>
+
+### Prerequisites
 
 Make sure you have following libraries installed on your OS:
 
@@ -13,23 +22,13 @@ Make sure you have following libraries installed on your OS:
 - libswresample-dev,
 - libmad0-dev
 
-### Ubuntu
-
-```shell
-apt install clang-format portaudio19-dev ffmpeg libavutil-dev libswresample-dev libmad0-dev
-```
-
-### macOS
-
 ```shell
 brew install clang-format portaudio ffmpeg libmad pkg-config
 ```
 
 Furthermore, make sure you have Elixir installed on your machine. For installation details, see: https://elixir-lang.org/install.html
 
-On Ubuntu, we recommend installation through `asdf`, see: https://asdf-vm.com/guide/getting-started.html
-
-## Running the demo
+### Running the demo
 
 To run the demo, clone the `membrane_demo` repository and checkout to the demo directory:
 
@@ -45,17 +44,69 @@ mix deps.get
 ```
 
 You may be asked to install `Hex` and then `rebar3`.
-In case of installation issues with Hex on Ubuntu, try updating the system packages first by entering the command:
-
-```shell
-sudo apt-get update
-```
 
 To start the demo pipeline run `mix run --no-halt run.exs` or type the following commands into an IEx shell (started by `iex -S mix`):
 
 ```elixir
 {:ok, _pid} = Membrane.Demo.SimplePipeline.start_link("sample.mp3")
 ```
+
+</details>
+
+<details>
+<summary>
+<b>Ubuntu</b>
+</summary>
+
+### Prerequisites
+
+Make sure you have following libraries installed on your OS:
+
+- clang-format,
+- portaudio19-dev,
+- FFmpeg 4.\*,
+- libavutil-dev,
+- libswresample-dev,
+- libmad0-dev
+
+```shell
+apt install clang-format portaudio19-dev ffmpeg libavutil-dev libswresample-dev libmad0-dev
+```
+
+Furthermore, make sure you have Elixir installed on your machine. For installation details, see: https://elixir-lang.org/install.html
+
+On Ubuntu, we recommend installation through `asdf`, see: https://asdf-vm.com/guide/getting-started.html
+
+### Running the demo
+
+To run the demo, clone the `membrane_demo` repository and checkout to the demo directory:
+
+```shell
+git clone https://github.com/membraneframework/membrane_demo
+cd membrane_demo/simple_pipeline
+```
+
+Then you need to download the dependencies of the mix project:
+
+```shell
+mix deps.get
+```
+
+You may be asked to install `Hex` and then `rebar3`.
+
+> In case of installation issues with Hex on Ubuntu, try updating the system packages first by entering the command:
+>
+> ```shell
+> sudo apt-get update
+> ```
+
+To start the demo pipeline run `mix run --no-halt run.exs` or type the following commands into an IEx shell (started by `iex -S mix`):
+
+```elixir
+{:ok, _pid} = Membrane.Demo.SimplePipeline.start_link("sample.mp3")
+```
+
+</details>
 
 ## Sample License
 

--- a/simple_pipeline/README.md
+++ b/simple_pipeline/README.md
@@ -4,26 +4,52 @@ This demo shows how to create a pipeline that plays an mp3 file.
 
 ## Prerequisites
 
-1. Make sure you have following libraries installed on your OS:
-   * clang-format, 
-   * portaudio19-dev, 
-   * ffmpeg, 
-   * libavutil-dev, 
-   * libswresample-dev, 
-   * libmad0-dev
-   
-    One-liner for Ubuntu
-    ```bash
-    apt install clang-format portaudio19-dev ffmpeg libavutil-dev libswresample-dev libmad0-dev
-    ```
-    One-liner for MacOS
-    ```bash
-    brew install clang-format portaudio ffmpeg libmad pkg-config
-    ```
-1. Make sure you have Elixir installed on your machine. See: https://elixir-lang.org/install.html
-1. Fetch the required dependencies by running `mix deps.get`
+Make sure you have following libraries installed on your OS:
 
-### How to run
+- clang-format,
+- portaudio19-dev,
+- FFmpeg 4.\*,
+- libavutil-dev,
+- libswresample-dev,
+- libmad0-dev
+
+### Ubuntu
+
+```shell
+apt install clang-format portaudio19-dev ffmpeg libavutil-dev libswresample-dev libmad0-dev
+```
+
+### macOS
+
+```shell
+brew install clang-format portaudio ffmpeg libmad pkg-config
+```
+
+Furthermore, make sure you have Elixir installed on your machine. For installation details, see: https://elixir-lang.org/install.html
+
+On Ubuntu, we recommend installation through `asdf`, see: https://asdf-vm.com/guide/getting-started.html
+
+## Running the demo
+
+To run the demo, clone the `membrane_demo` repository and checkout to the demo directory:
+
+```shell
+git clone https://github.com/membraneframework/membrane_demo
+cd membrane_demo/simple_pipeline
+```
+
+Then you need to download the dependencies of the mix project:
+
+```shell
+mix deps.get
+```
+
+You may be asked to install `Hex` and then `rebar3`.
+In case of installation issues with Hex on Ubuntu, try updating the system packages first by entering the command:
+
+```shell
+sudo apt-get update
+```
 
 To start the demo pipeline run `mix run --no-halt run.exs` or type the following commands into an IEx shell (started by `iex -S mix`):
 

--- a/video_mixer/README.md
+++ b/video_mixer/README.md
@@ -1,8 +1,8 @@
 # Membrane video mixer demo
 
 This demo shows how to mix audio and video files.  
-Audio files in .wav format are merged to single .aac file.  
-Video files in .h264 are merged into single .h264 file.
+Audio files in .wav format are merged into a single .aac file.  
+Video files in .h264 are merged into a single .h264 file.
 
 ## Prerequisites and running the demo
 
@@ -15,7 +15,7 @@ Below is the instruction for the installation of required dependencies and how t
 
 ### Prerequisites
 
-Make sure you have following libraries installed on your OS:
+Make sure you have the following libraries installed on your OS:
 
 - clang-format,
 - portaudio19-dev,
@@ -76,7 +76,7 @@ Mixed video and audio are saved in the `output.h264` and `output.aac` files, acc
 
 ### Prerequisites
 
-Make sure you have following libraries installed on your OS:
+Make sure you have the following libraries installed on your OS:
 
 - clang-format,
 - portaudio19-dev,

--- a/video_mixer/README.md
+++ b/video_mixer/README.md
@@ -6,36 +6,65 @@ Video files in .h264 are merged into single .h264 file.
 
 ## Prerequisites
 
-1. Make sure you have following libraries installed on your OS:
-   * clang-format, 
-   * portaudio19-dev, 
-   * ffmpeg, 
-   * libavutil-dev, 
-   * libswresample-dev, 
-   * libmad0-dev
-   
-    One-liner for Ubuntu
-    ```bash
-    apt install clang-format portaudio19-dev ffmpeg libavutil-dev libswresample-dev libmad0-dev libfdk-aac-dev
-    ```
-    One-liner for MacOS
-    ```bash
-    brew install clang-format portaudio ffmpeg libmad pkg-config fdk-aac
-    ```
-1. Make sure you have Elixir installed on your machine. See: https://elixir-lang.org/install.html
-1. Fetch the required dependencies by running `mix deps.get`
+Make sure you have following libraries installed on your OS:
 
-### How to run
+- clang-format,
+- portaudio19-dev,
+- FFmpeg 4.\*,
+- libavutil-dev,
+- libswresample-dev,
+- libmad0-dev
+
+### Ubuntu
+
+```shell
+apt install clang-format portaudio19-dev ffmpeg libavutil-dev libswresample-dev libmad0-dev libfdk-aac-dev
+```
+
+### macOS
+
+```shell
+brew install clang-format portaudio ffmpeg libmad pkg-config fdk-aac
+```
+
+Furthermore, make sure you have Elixir installed on your machine. For installation details, see: https://elixir-lang.org/install.html
+
+On Ubuntu, we recommend installation through `asdf`, see: https://asdf-vm.com/guide/getting-started.html
+
+## Running the demo
+
+To run the demo, clone the `membrane_demo` repository and checkout to the demo directory:
+
+```shell
+git clone https://github.com/membraneframework/membrane_demo
+cd membrane_demo/video_mixer
+```
+
+Then you need to download the dependencies of the mix project:
+
+```shell
+mix deps.get
+```
+
+You may be asked to install `Hex` and then `rebar3`.
+In case of installation issues with Hex on Ubuntu, try updating the system packages first by entering the command:
+
+```shell
+sudo apt-get update
+```
 
 To start the demo run `mix run --no-halt run.exs` or type the following commands into an IEx shell (started by `iex -S mix`):
 
 Start AudioPipeline
+
 ```elixir
 alias Membrane.Demo.AudioPipeline
 {:ok, pid} = AudioPipeline.start_link({"sound_500f.wav", "sound_1000f.wav"})
 AudioPipeline.play(pid)
 ```
+
 Start VideoPipeline
+
 ```elixir
 alias Membrane.Demo.VideoPipeline
 {:ok, pid} = VideoPipeline.start_link({"video_red.h264", "video_green.h264"})

--- a/video_mixer/README.md
+++ b/video_mixer/README.md
@@ -4,7 +4,16 @@ This demo shows how to mix audio and video files.
 Audio files in .wav format are merged to single .aac file.  
 Video files in .h264 are merged into single .h264 file.
 
-## Prerequisites
+## Prerequisites and running the demo
+
+Below is the instruction for the installation of required dependencies and how to run this demo on various operating systems:
+
+<details>
+<summary>
+<b>macOS</b>
+</summary>
+
+### Prerequisites
 
 Make sure you have following libraries installed on your OS:
 
@@ -15,23 +24,13 @@ Make sure you have following libraries installed on your OS:
 - libswresample-dev,
 - libmad0-dev
 
-### Ubuntu
-
-```shell
-apt install clang-format portaudio19-dev ffmpeg libavutil-dev libswresample-dev libmad0-dev libfdk-aac-dev
-```
-
-### macOS
-
 ```shell
 brew install clang-format portaudio ffmpeg libmad pkg-config fdk-aac
 ```
 
 Furthermore, make sure you have Elixir installed on your machine. For installation details, see: https://elixir-lang.org/install.html
 
-On Ubuntu, we recommend installation through `asdf`, see: https://asdf-vm.com/guide/getting-started.html
-
-## Running the demo
+### Running the demo
 
 To run the demo, clone the `membrane_demo` repository and checkout to the demo directory:
 
@@ -47,11 +46,6 @@ mix deps.get
 ```
 
 You may be asked to install `Hex` and then `rebar3`.
-In case of installation issues with Hex on Ubuntu, try updating the system packages first by entering the command:
-
-```shell
-sudo apt-get update
-```
 
 To start the demo run `mix run --no-halt run.exs` or type the following commands into an IEx shell (started by `iex -S mix`):
 
@@ -72,6 +66,77 @@ VideoPipeline.play(pid)
 ```
 
 Mixed video and audio are saved in the `output.h264` and `output.aac` files, accordingly.
+
+</details>
+
+<details>
+<summary>
+<b>Ubuntu</b>
+</summary>
+
+### Prerequisites
+
+Make sure you have following libraries installed on your OS:
+
+- clang-format,
+- portaudio19-dev,
+- FFmpeg 4.\*,
+- libavutil-dev,
+- libswresample-dev,
+- libmad0-dev
+
+```shell
+apt install clang-format portaudio19-dev ffmpeg libavutil-dev libswresample-dev libmad0-dev libfdk-aac-dev
+```
+
+Furthermore, make sure you have Elixir installed on your machine. For installation details, see: https://elixir-lang.org/install.html
+
+On Ubuntu, we recommend installation through `asdf`, see: https://asdf-vm.com/guide/getting-started.html
+
+### Running the demo
+
+To run the demo, clone the `membrane_demo` repository and checkout to the demo directory:
+
+```shell
+git clone https://github.com/membraneframework/membrane_demo
+cd membrane_demo/video_mixer
+```
+
+Then you need to download the dependencies of the mix project:
+
+```shell
+mix deps.get
+```
+
+You may be asked to install `Hex` and then `rebar3`.
+
+> In case of installation issues with Hex on Ubuntu, try updating the system packages first by entering the command:
+>
+> ```shell
+> sudo apt-get update
+> ```
+
+To start the demo run `mix run --no-halt run.exs` or type the following commands into an IEx shell (started by `iex -S mix`):
+
+Start AudioPipeline
+
+```elixir
+alias Membrane.Demo.AudioPipeline
+{:ok, pid} = AudioPipeline.start_link({"sound_500f.wav", "sound_1000f.wav"})
+AudioPipeline.play(pid)
+```
+
+Start VideoPipeline
+
+```elixir
+alias Membrane.Demo.VideoPipeline
+{:ok, pid} = VideoPipeline.start_link({"video_red.h264", "video_green.h264"})
+VideoPipeline.play(pid)
+```
+
+Mixed video and audio are saved in the `output.h264` and `output.aac` files, accordingly.
+
+</details>
 
 ## FAQ
 

--- a/webrtc_authentication/.gitignore
+++ b/webrtc_authentication/.gitignore
@@ -69,6 +69,7 @@ erl_crash.dump
 ## Private files ##
 /priv
 !/priv/certs/.gitkeep
+!/priv/repo/migrations/.gitkeep
 
 ### Elixir Patch ###
 ### Linux ###

--- a/webrtc_authentication/README.md
+++ b/webrtc_authentication/README.md
@@ -78,11 +78,13 @@ Configure a database for the application by running:
 psql -d postgres
 ```
 
+and then in the psql console:
+
 ```
 \du
 ```
 
-and change `username` in `config/config.exs` to the name of the user you have in table.
+Change `username` in `config/config.exs` to the name of the user you have in table.
 
 Then, create a database for the application:
 

--- a/webrtc_authentication/README.md
+++ b/webrtc_authentication/README.md
@@ -1,72 +1,141 @@
-# Membrane Demo - WebRTC Singaling Server 
+# Membrane Demo - WebRTC Singaling Server
 
 An example of signaling server with authentication based on `Membrane.WebRTC.Server`.
 
-## Configuration
+## Prerequisites
 
-Custom ip, port or other Plug options can be set up in `config/config.exs`. 
+Make sure you have `postgresql` installed on your computer.
 
-Download dependencies with
+### MacOS
+
+```console
+brew install postgresql
+```
+
+Then run the database server:
+
+```console
+brew services start postgresql
+```
+
+### Ubuntu
+
+```console
+sudo apt-get install postgresql
+```
+
+Then run the database server:
+
+```console
+sudo service postgresql start
+```
+
+Furthermore, make sure you have Elixir installed on your machine. For installation details, see: https://elixir-lang.org/install.html
+
+On Ubuntu, we recommend installation through asdf, see: https://asdf-vm.com/guide/getting-started.html
+
+## Running the demo
+
+To run the demo, clone the `membrane_demo` repository and checkout to the demo directory:
+
+```console
+git clone https://github.com/membraneframework/membrane_demo
+cd membrane_demo/webrtc_authentication
+```
+
+Custom ip, port or other Plug options can be set up in `config/config.exs`.
+
+Then you need to download the dependencies of the mix project:
 
 ```
-$ mix deps.get
+mix deps.get
+```
+
+Then you may be asked to install `Hex` and then `rebar3`.
+
+In case of installation issues with Hex on Ubuntu, try updating the system packages first by entering the command:
+
+```shell
+sudo apt-get update
 ```
 
 ### Guardian
 
-This application uses [Guardian](https://github.com/ueberauth/guardian) to authenticate 
-the users. Generate your secret key with
+This application uses [Guardian](https://github.com/ueberauth/guardian) to authenticate
+the users. Generate your secret key with:
 
 ```
-$ mix guardian.gen.secret
+mix guardian.gen.secret
 ```
 
-and add it to the config file (`config/config.exs`). Then, migrate the users table
+and add it to the config file (`config/config.exs`).
+
+### Database
+
+Configure a database for the application by running:
 
 ```
-$ mix ecto.migrate
+psql -d postgres
 ```
 
-And finally, create one or more users
+```
+\du
+```
+
+and change `username` in `config/config.exs` to the name of the user you have in table.
+
+Then, create a database for the application:
 
 ```
-$ iex -S mix
+mix ecto.create
+```
+
+and migrate the users table:
+
+```
+mix ecto.migrate
+```
+
+Finally, create one or more users:
+
+```
+iex -S mix
 iex> Example.Auth.UserManager.create_user(%{username: "username", password: "password"})
 ```
 
-If you want to connect to the application outside of your local network, you need to set up 
+If you want to connect to the application outside of your local network, you need to set up
 TURN and STUN servers. Insert their URLs in `rtcConfig` in `priv/static/js/main.js`.
- 
+
 ### HTTPS
 
 Since application uses HTTPS, certificate and key are needed to run it. You generate them with
 
 ```
-$ openssl req -newkey rsa:2048 -nodes -keyout priv/certs/key.pem -x509 -days 365 -out priv/certs/certificate.pem
+openssl req -newkey rsa:2048 -nodes -keyout priv/certs/key.pem -x509 -days 365 -out priv/certs/certificate.pem
 ```
 
 Note that this certificate is not validated and thus may cause warnings in browser.
 
 To trust self-signed certificate follow instructions below:
 
-### Debian
+### Ubuntu
 
 ```
-$ apt install ca-certificates
-$ cp priv/certs/certificate.pem /usr/local/share/ca-certificates/
-$ update-ca-certificates
+apt install ca-certificates
+cp priv/certs/certificate.pem /usr/local/share/ca-certificates/
+update-ca-certificates
 ```
 
 ### Arch
 
 ```
-$ trust anchor --store priv/certs/certificate.pem
+trust anchor --store priv/certs/certificate.pem
 ```
 
 ### MacOS
 
 ```
-$ security import priv/certs/certificate.pem -k ~/Library/Keychains/login.keychain-db
+security import priv/certs/certificate.pem -k ~/Library/Keychains/login.keychain-db
 ```
 
 Then, find your certificate in Keychains, open it, expand the Trust section and change
@@ -74,15 +143,19 @@ the SSL setting to "Always Trust".
 
 ## Usage
 
-Run application with
+Run application with:
 
 ```
-$ mix start
+mix start
 ```
 
-You can join videochat in: `https://YOUR-IP-ADDRESS:PORT/` (by default, it will be 
+You can join videochat in: `https://YOUR-IP-ADDRESS:PORT/` (by default, it will be
 https://0.0.0.0:8443/). After logging in, you should see video stream from your and every other
 peer cameras.
+
+_You might be asked to grant access to your camera, as some operating systems require that._
+
+_In case of the absence of a physical camera, it is necessary to use a virtual camera (e.g. OBS)._
 
 ## Copyright and License
 

--- a/webrtc_authentication/README.md
+++ b/webrtc_authentication/README.md
@@ -2,11 +2,18 @@
 
 An example of signaling server with authentication based on `Membrane.WebRTC.Server`.
 
-## Prerequisites
+## Prerequisites and running the demo
+
+Below is the instruction for the installation of required dependencies and how to run this demo on various operating systems:
+
+<details>
+<summary>
+<b>macOS</b>
+</summary>
+
+### Prerequisites
 
 Make sure you have `postgresql` installed on your computer.
-
-### macOS
 
 ```shell
 brew install postgresql
@@ -18,23 +25,9 @@ Then run the database server:
 brew services start postgresql
 ```
 
-### Ubuntu
-
-```shell
-sudo apt-get install postgresql
-```
-
-Then run the database server:
-
-```shell
-sudo service postgresql start
-```
-
 Furthermore, make sure you have Elixir installed on your machine. For installation details, see: https://elixir-lang.org/install.html
 
-On Ubuntu, we recommend installation through `asdf`, see: https://asdf-vm.com/guide/getting-started.html
-
-## Running the demo
+### Running the demo
 
 To run the demo, clone the `membrane_demo` repository and checkout to the demo directory:
 
@@ -52,13 +45,8 @@ mix deps.get
 ```
 
 You may be asked to install `Hex` and then `rebar3`.
-In case of installation issues with Hex on Ubuntu, try updating the system packages first by entering the command:
 
-```shell
-sudo apt-get update
-```
-
-### Guardian
+#### Guardian
 
 This application uses [Guardian](https://github.com/ueberauth/guardian) to authenticate
 the users. Generate your secret key with:
@@ -69,7 +57,7 @@ mix guardian.gen.secret
 
 and add it to the config file (`config/config.exs`).
 
-### Database
+#### Database
 
 Configure database in `config/config.exs`. In case you are not sure about the configuration that should be passed in `config/config.exs`, you can try to connect with you database with the use of `psql`.
 
@@ -95,7 +83,7 @@ iex> Example.Auth.UserManager.create_user(%{username: "username", password: "pas
 If you want to connect to the application outside of your local network, you need to set up
 TURN and STUN servers. Insert their URLs in `rtcConfig` in `priv/static/js/main.js`.
 
-### HTTPS
+#### HTTPS
 
 Since application uses HTTPS, certificate and key are needed to run it. You generate them with
 
@@ -107,22 +95,6 @@ Note that this certificate is not validated and thus may cause warnings in brows
 
 To trust self-signed certificate follow instructions below:
 
-### Ubuntu
-
-```shell
-apt install ca-certificates
-cp priv/certs/certificate.pem /usr/local/share/ca-certificates/
-update-ca-certificates
-```
-
-### Arch
-
-```shell
-trust anchor --store priv/certs/certificate.pem
-```
-
-### macOS
-
 ```shell
 security import priv/certs/certificate.pem -k ~/Library/Keychains/login.keychain-db
 ```
@@ -130,7 +102,7 @@ security import priv/certs/certificate.pem -k ~/Library/Keychains/login.keychain
 Then, find your certificate in Keychains, open it, expand the Trust section and change
 the SSL setting to "Always Trust".
 
-## Usage
+### Usage
 
 Run application with:
 
@@ -145,6 +117,240 @@ peer cameras.
 _You might be asked to grant access to your camera, as some operating systems require that._
 
 _In case of the absence of a physical camera, it is necessary to use a virtual camera (e.g. OBS, [see how to set up the virtual camera in OBS](https://obsproject.com/kb/virtual-camera-guide))_
+
+</details>
+
+<details>
+<summary>
+<b>Ubuntu</b>
+</summary>
+
+### Prerequisites
+
+Make sure you have `postgresql` installed on your computer.
+
+```shell
+sudo apt-get install postgresql
+```
+
+Then run the database server:
+
+```shell
+sudo service postgresql start
+```
+
+Furthermore, make sure you have Elixir installed on your machine. For installation details, see: https://elixir-lang.org/install.html
+
+On Ubuntu, we recommend installation through `asdf`, see: https://asdf-vm.com/guide/getting-started.html
+
+### Running the demo
+
+To run the demo, clone the `membrane_demo` repository and checkout to the demo directory:
+
+```shell
+git clone https://github.com/membraneframework/membrane_demo
+cd membrane_demo/webrtc_authentication
+```
+
+Custom database's IP, port, name and other `Plug` options can be set up in `config/config.exs`.
+
+Then you need to download the dependencies of the mix project:
+
+```shell
+mix deps.get
+```
+
+You may be asked to install `Hex` and then `rebar3`.
+
+> In case of installation issues with Hex on Ubuntu, try updating the system packages first by entering the command:
+>
+> ```shell
+> sudo apt-get update
+> ```
+
+#### Guardian
+
+This application uses [Guardian](https://github.com/ueberauth/guardian) to authenticate
+the users. Generate your secret key with:
+
+```shell
+mix guardian.gen.secret
+```
+
+and add it to the config file (`config/config.exs`).
+
+#### Database
+
+Configure database in `config/config.exs`. In case you are not sure about the configuration that should be passed in `config/config.exs`, you can try to connect with you database with the use of `psql`.
+
+Then, create a database for the application:
+
+```shell
+mix ecto.create
+```
+
+and migrate the users table:
+
+```shell
+mix ecto.migrate
+```
+
+Finally, create one or more users:
+
+```elixir
+iex -S mix
+iex> Example.Auth.UserManager.create_user(%{username: "username", password: "password"})
+```
+
+If you want to connect to the application outside of your local network, you need to set up
+TURN and STUN servers. Insert their URLs in `rtcConfig` in `priv/static/js/main.js`.
+
+#### HTTPS
+
+Since application uses HTTPS, certificate and key are needed to run it. You generate them with
+
+```shell
+openssl req -newkey rsa:2048 -nodes -keyout priv/certs/key.pem -x509 -days 365 -out priv/certs/certificate.pem
+```
+
+Note that this certificate is not validated and thus may cause warnings in browser.
+
+To trust self-signed certificate follow instructions below:
+
+```shell
+apt install ca-certificates
+cp priv/certs/certificate.pem /usr/local/share/ca-certificates/
+update-ca-certificates
+```
+
+### Usage
+
+Run application with:
+
+```shell
+mix start
+```
+
+You can join videochat in: `https://YOUR-IP-ADDRESS:PORT/` (by default, it will be
+https://0.0.0.0:8443/). After logging in, you should see video stream from your and every other
+peer cameras.
+
+_You might be asked to grant access to your camera, as some operating systems require that._
+
+_In case of the absence of a physical camera, it is necessary to use a virtual camera (e.g. OBS, [see how to set up the virtual camera in OBS](https://obsproject.com/kb/virtual-camera-guide))_
+
+</details>
+
+<details>
+<summary>
+<b>Arch</b>
+</summary>
+
+### Prerequisites
+
+Make sure you have `postgresql` installed on your computer.
+
+```shell
+sudo pacman -S postgresql
+```
+
+Then run the database server:
+
+```shell
+sudo systemctl start postgresql
+```
+
+Furthermore, make sure you have Elixir installed on your machine. For installation details, see: https://elixir-lang.org/install.html
+
+### Running the demo
+
+To run the demo, clone the `membrane_demo` repository and checkout to the demo directory:
+
+```shell
+git clone https://github.com/membraneframework/membrane_demo
+cd membrane_demo/webrtc_authentication
+```
+
+Custom database's IP, port, name and other `Plug` options can be set up in `config/config.exs`.
+
+Then you need to download the dependencies of the mix project:
+
+```shell
+mix deps.get
+```
+
+You may be asked to install `Hex` and then `rebar3`.
+
+#### Guardian
+
+This application uses [Guardian](https://github.com/ueberauth/guardian) to authenticate
+the users. Generate your secret key with:
+
+```shell
+mix guardian.gen.secret
+```
+
+and add it to the config file (`config/config.exs`).
+
+#### Database
+
+Configure database in `config/config.exs`. In case you are not sure about the configuration that should be passed in `config/config.exs`, you can try to connect with you database with the use of `psql`.
+
+Then, create a database for the application:
+
+```shell
+mix ecto.create
+```
+
+and migrate the users table:
+
+```shell
+mix ecto.migrate
+```
+
+Finally, create one or more users:
+
+```elixir
+iex -S mix
+iex> Example.Auth.UserManager.create_user(%{username: "username", password: "password"})
+```
+
+If you want to connect to the application outside of your local network, you need to set up
+TURN and STUN servers. Insert their URLs in `rtcConfig` in `priv/static/js/main.js`.
+
+#### HTTPS
+
+Since application uses HTTPS, certificate and key are needed to run it. You generate them with
+
+```shell
+openssl req -newkey rsa:2048 -nodes -keyout priv/certs/key.pem -x509 -days 365 -out priv/certs/certificate.pem
+```
+
+Note that this certificate is not validated and thus may cause warnings in browser.
+
+To trust self-signed certificate follow instructions below:
+
+```shell
+trust anchor --store priv/certs/certificate.pem
+```
+
+### Usage
+
+Run application with:
+
+```shell
+mix start
+```
+
+You can join videochat in: `https://YOUR-IP-ADDRESS:PORT/` (by default, it will be
+https://0.0.0.0:8443/). After logging in, you should see video stream from your and every other
+peer cameras.
+
+_You might be asked to grant access to your camera, as some operating systems require that._
+
+_In case of the absence of a physical camera, it is necessary to use a virtual camera (e.g. OBS, [see how to set up the virtual camera in OBS](https://obsproject.com/kb/virtual-camera-guide))_
+
+</details>
 
 ## Copyright and License
 

--- a/webrtc_authentication/README.md
+++ b/webrtc_authentication/README.md
@@ -6,7 +6,7 @@ An example of signaling server with authentication based on `Membrane.WebRTC.Ser
 
 Make sure you have `postgresql` installed on your computer.
 
-### MacOS
+### macOS
 
 ```shell
 brew install postgresql
@@ -71,21 +71,7 @@ and add it to the config file (`config/config.exs`).
 
 ### Database
 
-<!-- This part will be updated -->
-
-Configure a database for the application by running:
-
-```shell
-psql -d postgres
-```
-
-and then in the psql console:
-
-```shell
-\du
-```
-
-Change `username` in `config/config.exs` to the name of the user you have in table.
+Configure database in `config/config.exs`. In case you are not sure about the configuration that should be passed in `config/config.exs`, you can try to connect with you database with the use of `psql`.
 
 Then, create a database for the application:
 
@@ -135,11 +121,9 @@ update-ca-certificates
 trust anchor --store priv/certs/certificate.pem
 ```
 
-### MacOS
+### macOS
 
-shell
-
-```
+```shell
 security import priv/certs/certificate.pem -k ~/Library/Keychains/login.keychain-db
 ```
 

--- a/webrtc_authentication/README.md
+++ b/webrtc_authentication/README.md
@@ -8,37 +8,37 @@ Make sure you have `postgresql` installed on your computer.
 
 ### MacOS
 
-```console
+```shell
 brew install postgresql
 ```
 
 Then run the database server:
 
-```console
+```shell
 brew services start postgresql
 ```
 
 ### Ubuntu
 
-```console
+```shell
 sudo apt-get install postgresql
 ```
 
 Then run the database server:
 
-```console
+```shell
 sudo service postgresql start
 ```
 
 Furthermore, make sure you have Elixir installed on your machine. For installation details, see: https://elixir-lang.org/install.html
 
-On Ubuntu, we recommend installation through asdf, see: https://asdf-vm.com/guide/getting-started.html
+On Ubuntu, we recommend installation through `asdf`, see: https://asdf-vm.com/guide/getting-started.html
 
 ## Running the demo
 
 To run the demo, clone the `membrane_demo` repository and checkout to the demo directory:
 
-```console
+```shell
 git clone https://github.com/membraneframework/membrane_demo
 cd membrane_demo/webrtc_authentication
 ```
@@ -47,12 +47,11 @@ Custom database's IP, port, name and other `Plug` options can be set up in `conf
 
 Then you need to download the dependencies of the mix project:
 
-```
+```shell
 mix deps.get
 ```
 
-Then you may be asked to install `Hex` and then `rebar3`.
-
+You may be asked to install `Hex` and then `rebar3`.
 In case of installation issues with Hex on Ubuntu, try updating the system packages first by entering the command:
 
 ```shell
@@ -64,7 +63,7 @@ sudo apt-get update
 This application uses [Guardian](https://github.com/ueberauth/guardian) to authenticate
 the users. Generate your secret key with:
 
-```
+```shell
 mix guardian.gen.secret
 ```
 
@@ -72,15 +71,17 @@ and add it to the config file (`config/config.exs`).
 
 ### Database
 
+<!-- This part will be updated -->
+
 Configure a database for the application by running:
 
-```
+```shell
 psql -d postgres
 ```
 
 and then in the psql console:
 
-```
+```shell
 \du
 ```
 
@@ -88,19 +89,19 @@ Change `username` in `config/config.exs` to the name of the user you have in tab
 
 Then, create a database for the application:
 
-```
+```shell
 mix ecto.create
 ```
 
 and migrate the users table:
 
-```
+```shell
 mix ecto.migrate
 ```
 
 Finally, create one or more users:
 
-```
+```elixir
 iex -S mix
 iex> Example.Auth.UserManager.create_user(%{username: "username", password: "password"})
 ```
@@ -112,7 +113,7 @@ TURN and STUN servers. Insert their URLs in `rtcConfig` in `priv/static/js/main.
 
 Since application uses HTTPS, certificate and key are needed to run it. You generate them with
 
-```
+```shell
 openssl req -newkey rsa:2048 -nodes -keyout priv/certs/key.pem -x509 -days 365 -out priv/certs/certificate.pem
 ```
 
@@ -122,7 +123,7 @@ To trust self-signed certificate follow instructions below:
 
 ### Ubuntu
 
-```
+```shell
 apt install ca-certificates
 cp priv/certs/certificate.pem /usr/local/share/ca-certificates/
 update-ca-certificates
@@ -130,11 +131,13 @@ update-ca-certificates
 
 ### Arch
 
-```
+```shell
 trust anchor --store priv/certs/certificate.pem
 ```
 
 ### MacOS
+
+shell
 
 ```
 security import priv/certs/certificate.pem -k ~/Library/Keychains/login.keychain-db
@@ -147,7 +150,7 @@ the SSL setting to "Always Trust".
 
 Run application with:
 
-```
+```shell
 mix start
 ```
 
@@ -157,7 +160,7 @@ peer cameras.
 
 _You might be asked to grant access to your camera, as some operating systems require that._
 
-_In case of the absence of a physical camera, it is necessary to use a virtual camera (e.g. OBS)._
+_In case of the absence of a physical camera, it is necessary to use a virtual camera (e.g. OBS, [see how to set up the virtual camera in OBS](https://obsproject.com/kb/virtual-camera-guide))_
 
 ## Copyright and License
 

--- a/webrtc_authentication/README.md
+++ b/webrtc_authentication/README.md
@@ -43,7 +43,7 @@ git clone https://github.com/membraneframework/membrane_demo
 cd membrane_demo/webrtc_authentication
 ```
 
-Custom ip, port or other Plug options can be set up in `config/config.exs`.
+Custom database's IP, port, name and other `Plug` options can be set up in `config/config.exs`.
 
 Then you need to download the dependencies of the mix project:
 

--- a/webrtc_authentication/README.md
+++ b/webrtc_authentication/README.md
@@ -1,6 +1,6 @@
-# Membrane Demo - WebRTC Singaling Server
+# Membrane Demo - WebRTC Signaling Server
 
-An example of signaling server with authentication based on `Membrane.WebRTC.Server`.
+An example of a signaling server with authentication based on `Membrane.WebRTC.Server`.
 
 ## Prerequisites and running the demo
 
@@ -36,7 +36,7 @@ git clone https://github.com/membraneframework/membrane_demo
 cd membrane_demo/webrtc_authentication
 ```
 
-Custom database's IP, port, name and other `Plug` options can be set up in `config/config.exs`.
+Custom database's IP, port, name, and other `Plug` options can be set up in `config/config.exs`.
 
 Then you need to download the dependencies of the mix project:
 
@@ -69,7 +69,7 @@ Then, create a database for the application:
 mix ecto.create
 ```
 
-and migrate the users table:
+and migrate the user's table:
 
 ```shell
 mix ecto.migrate
@@ -87,34 +87,34 @@ TURN and STUN servers. Insert their URLs in `rtcConfig` in `priv/static/js/main.
 
 #### HTTPS
 
-Since application uses HTTPS, certificate and key are needed to run it. You generate them with
+Since the application uses HTTPS, a certificate and key are needed to run it. You generate them with
 
 ```shell
 openssl req -newkey rsa:2048 -nodes -keyout priv/certs/key.pem -x509 -days 365 -out priv/certs/certificate.pem
 ```
 
-Note that this certificate is not validated and thus may cause warnings in browser.
+Note that this certificate is not validated and thus may cause warnings in the browser.
 
-To trust self-signed certificate follow instructions below:
+To trust the self-signed certificate follow the instructions below:
 
 ```shell
 security import priv/certs/certificate.pem -k ~/Library/Keychains/login.keychain-db
 ```
 
-Then, find your certificate in Keychains, open it, expand the Trust section and change
+Then, find your certificate in Keychains, open it, expand the Trust section, and change
 the SSL setting to "Always Trust".
 
 ### Usage
 
-Run application with:
+Run the application with:
 
 ```shell
 mix start
 ```
 
-You can join videochat in: `https://YOUR-IP-ADDRESS:PORT/` (by default, it will be
-https://0.0.0.0:8443/). After logging in, you should see video stream from your and every other
-peer cameras.
+You can join videochat at: `https://YOUR-IP-ADDRESS:PORT/` (by default, it will be
+https://0.0.0.0:8443/). After logging in, you should see a video stream from your and every other
+peer's cameras.
 
 _You might be asked to grant access to your camera, as some operating systems require that._
 
@@ -154,7 +154,7 @@ git clone https://github.com/membraneframework/membrane_demo
 cd membrane_demo/webrtc_authentication
 ```
 
-Custom database's IP, port, name and other `Plug` options can be set up in `config/config.exs`.
+Custom database's IP, port, name, and other `Plug` options can be set up in `config/config.exs`.
 
 Then you need to download the dependencies of the mix project:
 
@@ -193,7 +193,7 @@ Then, create a database for the application:
 mix ecto.create
 ```
 
-and migrate the users table:
+and migrate the user's table:
 
 ```shell
 mix ecto.migrate
@@ -211,15 +211,15 @@ TURN and STUN servers. Insert their URLs in `rtcConfig` in `priv/static/js/main.
 
 #### HTTPS
 
-Since application uses HTTPS, certificate and key are needed to run it. You generate them with
+Since the application uses HTTPS, a certificate and key are needed to run it. You generate them with
 
 ```shell
 openssl req -newkey rsa:2048 -nodes -keyout priv/certs/key.pem -x509 -days 365 -out priv/certs/certificate.pem
 ```
 
-Note that this certificate is not validated and thus may cause warnings in browser.
+Note that this certificate is not validated and thus may cause warnings in the browser.
 
-To trust self-signed certificate follow instructions below:
+To trust the self-signed certificate follow the instructions below:
 
 ```shell
 apt install ca-certificates
@@ -229,15 +229,15 @@ update-ca-certificates
 
 ### Usage
 
-Run application with:
+Run the application with:
 
 ```shell
 mix start
 ```
 
-You can join videochat in: `https://YOUR-IP-ADDRESS:PORT/` (by default, it will be
-https://0.0.0.0:8443/). After logging in, you should see video stream from your and every other
-peer cameras.
+You can join videochat at: `https://YOUR-IP-ADDRESS:PORT/` (by default, it will be
+https://0.0.0.0:8443/). After logging in, you should see a video stream from your and every other
+peer's cameras.
 
 _You might be asked to grant access to your camera, as some operating systems require that._
 
@@ -275,7 +275,7 @@ git clone https://github.com/membraneframework/membrane_demo
 cd membrane_demo/webrtc_authentication
 ```
 
-Custom database's IP, port, name and other `Plug` options can be set up in `config/config.exs`.
+Custom database's IP, port, name, and other `Plug` options can be set up in `config/config.exs`.
 
 Then you need to download the dependencies of the mix project:
 
@@ -308,7 +308,7 @@ Then, create a database for the application:
 mix ecto.create
 ```
 
-and migrate the users table:
+and migrate the user's table:
 
 ```shell
 mix ecto.migrate
@@ -326,15 +326,15 @@ TURN and STUN servers. Insert their URLs in `rtcConfig` in `priv/static/js/main.
 
 #### HTTPS
 
-Since application uses HTTPS, certificate and key are needed to run it. You generate them with
+Since the application uses HTTPS, a certificate and key are needed to run it. You generate them with
 
 ```shell
 openssl req -newkey rsa:2048 -nodes -keyout priv/certs/key.pem -x509 -days 365 -out priv/certs/certificate.pem
 ```
 
-Note that this certificate is not validated and thus may cause warnings in browser.
+Note that this certificate is not validated and thus may cause warnings in the browser.
 
-To trust self-signed certificate follow instructions below:
+To trust the self-signed certificate follow the instructions below:
 
 ```shell
 trust anchor --store priv/certs/certificate.pem
@@ -342,15 +342,15 @@ trust anchor --store priv/certs/certificate.pem
 
 ### Usage
 
-Run application with:
+Run the application with:
 
 ```shell
 mix start
 ```
 
-You can join videochat in: `https://YOUR-IP-ADDRESS:PORT/` (by default, it will be
-https://0.0.0.0:8443/). After logging in, you should see video stream from your and every other
-peer cameras.
+You can join videochat at: `https://YOUR-IP-ADDRESS:PORT/` (by default, it will be
+https://0.0.0.0:8443/). After logging in, you should see a video stream from your and every other
+peer's cameras.
 
 _You might be asked to grant access to your camera, as some operating systems require that._
 

--- a/webrtc_authentication/README.md
+++ b/webrtc_authentication/README.md
@@ -59,7 +59,9 @@ and add it to the config file (`config/config.exs`).
 
 #### Database
 
-Configure database in `config/config.exs`. In case you are not sure about the configuration that should be passed in `config/config.exs`, you can try to connect with you database with the use of `psql`.
+Configure database in `config/config.exs`.
+
+> In case you are not sure about the configuration that should be passed in `config/config.exs`, you can try to connect with your database with the use of `psql`.
 
 Then, create a database for the application:
 
@@ -181,7 +183,9 @@ and add it to the config file (`config/config.exs`).
 
 #### Database
 
-Configure database in `config/config.exs`. In case you are not sure about the configuration that should be passed in `config/config.exs`, you can try to connect with you database with the use of `psql`.
+Configure database in `config/config.exs`.
+
+> In case you are not sure about the configuration that should be passed in `config/config.exs`, you can try to connect with your database with the use of `psql`.
 
 Then, create a database for the application:
 
@@ -294,7 +298,9 @@ and add it to the config file (`config/config.exs`).
 
 #### Database
 
-Configure database in `config/config.exs`. In case you are not sure about the configuration that should be passed in `config/config.exs`, you can try to connect with you database with the use of `psql`.
+Configure database in `config/config.exs`.
+
+> In case you are not sure about the configuration that should be passed in `config/config.exs`, you can try to connect with your database with the use of `psql`.
 
 Then, create a database for the application:
 

--- a/webrtc_simple/README.md
+++ b/webrtc_simple/README.md
@@ -58,7 +58,7 @@ update-ca-certificates
 trust anchor --store priv/certs/certificate.pem
 ```
 
-### MacOS
+### macOS
 
 ```shell
 security import priv/certs/certificate.pem -k ~/Library/Keychains/login.keychain-db

--- a/webrtc_simple/README.md
+++ b/webrtc_simple/README.md
@@ -6,13 +6,13 @@ Simple example of signaling server based on `Membrane.WebRTC.Server`.
 
 Make sure you have Elixir installed on your machine. For installation details, see: https://elixir-lang.org/install.html
 
-On Ubuntu, we recommend installation through asdf, see: https://asdf-vm.com/guide/getting-started.html
+On Ubuntu, we recommend installation through `asdf`, see: https://asdf-vm.com/guide/getting-started.html
 
 ## Running the demo
 
 To run the demo, clone the `membrane_demo` repository and checkout to the demo directory:
 
-```console
+```shell
 git clone https://github.com/membraneframework/membrane_demo
 cd membrane_demo/webrtc_simple
 ```
@@ -21,12 +21,11 @@ Custom ip, port or other Plug options can be set up in `config/config.exs`.
 
 Then you need to download the dependencies of the mix project:
 
-```
+```shell
 mix deps.get
 ```
 
-Then you may be asked to install `Hex` and then `rebar3`.
-
+You may be asked to install `Hex` and then `rebar3`.
 In case of installation issues with Hex on Ubuntu, try updating the system packages first by entering the command:
 
 ```shell
@@ -37,7 +36,7 @@ sudo apt-get update
 
 Since application uses HTTPS, certificate and key are needed to run it. You generate them with
 
-```
+```shell
 openssl req -newkey rsa:2048 -nodes -keyout priv/certs/key.pem -x509 -days 365 -out priv/certs/certificate.pem
 ```
 
@@ -47,7 +46,7 @@ To trust self-signed certificate follow instructions below:
 
 ### Ubuntu
 
-```
+```shell
 apt install ca-certificates
 cp priv/certs/certificate.pem /usr/local/share/ca-certificates/
 update-ca-certificates
@@ -55,13 +54,13 @@ update-ca-certificates
 
 ### Arch
 
-```
+```shell
 trust anchor --store priv/certs/certificate.pem
 ```
 
 ### MacOS
 
-```
+```shell
 security import priv/certs/certificate.pem -k ~/Library/Keychains/login.keychain-db
 ```
 
@@ -72,7 +71,7 @@ the SSL setting to "Always Trust".
 
 Run application with:
 
-```
+```shell
 mix start
 ```
 
@@ -82,7 +81,7 @@ video stream from your and every other peer cameras.
 
 _You might be asked to grant access to your camera, as some operating systems require that._
 
-_In case of the absence of a physical camera, it is necessary to use a virtual camera (e.g. OBS)._
+_In case of the absence of a physical camera, it is necessary to use a virtual camera (e.g. OBS, [see how to set up the virtual camera in OBS](https://obsproject.com/kb/virtual-camera-guide))_
 
 ## Copyright and License
 

--- a/webrtc_simple/README.md
+++ b/webrtc_simple/README.md
@@ -1,15 +1,36 @@
-# Membrane Demo - WebRTC Singaling Server 
+# Membrane Demo - WebRTC Singaling Server
 
 Simple example of signaling server based on `Membrane.WebRTC.Server`.
 
-## Configuration
+## Prerequisites
 
-Custom ip, port or other Plug options can be set up in `config/config.exs`. 
+Make sure you have Elixir installed on your machine. For installation details, see: https://elixir-lang.org/install.html
 
-Download dependencies with
+On Ubuntu, we recommend installation through asdf, see: https://asdf-vm.com/guide/getting-started.html
+
+## Running the demo
+
+To run the demo, clone the `membrane_demo` repository and checkout to the demo directory:
+
+```console
+git clone https://github.com/membraneframework/membrane_demo
+cd membrane_demo/webrtc_simple
+```
+
+Custom ip, port or other Plug options can be set up in `config/config.exs`.
+
+Then you need to download the dependencies of the mix project:
 
 ```
-$ mix deps.get
+mix deps.get
+```
+
+Then you may be asked to install `Hex` and then `rebar3`.
+
+In case of installation issues with Hex on Ubuntu, try updating the system packages first by entering the command:
+
+```shell
+sudo apt-get update
 ```
 
 ### HTTPS
@@ -17,31 +38,31 @@ $ mix deps.get
 Since application uses HTTPS, certificate and key are needed to run it. You generate them with
 
 ```
-$ openssl req -newkey rsa:2048 -nodes -keyout priv/certs/key.pem -x509 -days 365 -out priv/certs/certificate.pem
+openssl req -newkey rsa:2048 -nodes -keyout priv/certs/key.pem -x509 -days 365 -out priv/certs/certificate.pem
 ```
 
 Note that this certificate is not validated and thus may cause warnings in browser.
 
 To trust self-signed certificate follow instructions below:
 
-### Debian
+### Ubuntu
 
 ```
-$ apt install ca-certificates
-$ cp priv/certs/certificate.pem /usr/local/share/ca-certificates/
-$ update-ca-certificates
+apt install ca-certificates
+cp priv/certs/certificate.pem /usr/local/share/ca-certificates/
+update-ca-certificates
 ```
 
 ### Arch
 
 ```
-$ trust anchor --store priv/certs/certificate.pem
+trust anchor --store priv/certs/certificate.pem
 ```
 
 ### MacOS
 
 ```
-$ security import priv/certs/certificate.pem -k ~/Library/Keychains/login.keychain-db
+security import priv/certs/certificate.pem -k ~/Library/Keychains/login.keychain-db
 ```
 
 Then, find your certificate in Keychains, open it, expand the Trust section and change
@@ -49,15 +70,19 @@ the SSL setting to "Always Trust".
 
 ## Usage
 
-Run application with
+Run application with:
 
 ```
-$ mix start
+mix start
 ```
 
-You can join videochat in: 
-`https://YOUR-IP-ADDRESS:PORT/NAME-OF-ROOM`, for example [here](https://localhost:8443/room). You should see 
+You can join videochat in:
+`https://YOUR-IP-ADDRESS:PORT/NAME-OF-ROOM`, for example [here](https://localhost:8443/room). You should see
 video stream from your and every other peer cameras.
+
+_You might be asked to grant access to your camera, as some operating systems require that._
+
+_In case of the absence of a physical camera, it is necessary to use a virtual camera (e.g. OBS)._
 
 ## Copyright and License
 

--- a/webrtc_simple/README.md
+++ b/webrtc_simple/README.md
@@ -2,13 +2,20 @@
 
 Simple example of signaling server based on `Membrane.WebRTC.Server`.
 
-## Prerequisites
+## Prerequisites and running the demo
+
+Below is the instruction for the installation of required dependencies and how to run this demo on various operating systems:
+
+<details>
+<summary>
+<b>macOS</b>
+</summary>
+
+### Prerequisites
 
 Make sure you have Elixir installed on your machine. For installation details, see: https://elixir-lang.org/install.html
 
-On Ubuntu, we recommend installation through `asdf`, see: https://asdf-vm.com/guide/getting-started.html
-
-## Running the demo
+### Running the demo
 
 To run the demo, clone the `membrane_demo` repository and checkout to the demo directory:
 
@@ -26,13 +33,8 @@ mix deps.get
 ```
 
 You may be asked to install `Hex` and then `rebar3`.
-In case of installation issues with Hex on Ubuntu, try updating the system packages first by entering the command:
 
-```shell
-sudo apt-get update
-```
-
-### HTTPS
+#### HTTPS
 
 Since application uses HTTPS, certificate and key are needed to run it. You generate them with
 
@@ -44,22 +46,6 @@ Note that this certificate is not validated and thus may cause warnings in brows
 
 To trust self-signed certificate follow instructions below:
 
-### Ubuntu
-
-```shell
-apt install ca-certificates
-cp priv/certs/certificate.pem /usr/local/share/ca-certificates/
-update-ca-certificates
-```
-
-### Arch
-
-```shell
-trust anchor --store priv/certs/certificate.pem
-```
-
-### macOS
-
 ```shell
 security import priv/certs/certificate.pem -k ~/Library/Keychains/login.keychain-db
 ```
@@ -67,7 +53,7 @@ security import priv/certs/certificate.pem -k ~/Library/Keychains/login.keychain
 Then, find your certificate in Keychains, open it, expand the Trust section and change
 the SSL setting to "Always Trust".
 
-## Usage
+### Usage
 
 Run application with:
 
@@ -82,6 +68,142 @@ video stream from your and every other peer cameras.
 _You might be asked to grant access to your camera, as some operating systems require that._
 
 _In case of the absence of a physical camera, it is necessary to use a virtual camera (e.g. OBS, [see how to set up the virtual camera in OBS](https://obsproject.com/kb/virtual-camera-guide))_
+
+</details>
+
+<details>
+<summary>
+<b>Ubuntu</b>
+</summary>
+
+### Prerequisites
+
+Make sure you have Elixir installed on your machine. For installation details, see: https://elixir-lang.org/install.html
+
+On Ubuntu, we recommend installation through `asdf`, see: https://asdf-vm.com/guide/getting-started.html
+
+### Running the demo
+
+To run the demo, clone the `membrane_demo` repository and checkout to the demo directory:
+
+```shell
+git clone https://github.com/membraneframework/membrane_demo
+cd membrane_demo/webrtc_simple
+```
+
+Custom ip, port or other Plug options can be set up in `config/config.exs`.
+
+Then you need to download the dependencies of the mix project:
+
+```shell
+mix deps.get
+```
+
+You may be asked to install `Hex` and then `rebar3`.
+
+> In case of installation issues with Hex on Ubuntu, try updating the system packages first by entering the command:
+>
+> ```shell
+> sudo apt-get update
+> ```
+
+#### HTTPS
+
+Since application uses HTTPS, certificate and key are needed to run it. You generate them with
+
+```shell
+openssl req -newkey rsa:2048 -nodes -keyout priv/certs/key.pem -x509 -days 365 -out priv/certs/certificate.pem
+```
+
+Note that this certificate is not validated and thus may cause warnings in browser.
+
+To trust self-signed certificate follow instructions below:
+
+```shell
+apt install ca-certificates
+cp priv/certs/certificate.pem /usr/local/share/ca-certificates/
+update-ca-certificates
+```
+
+### Usage
+
+Run application with:
+
+```shell
+mix start
+```
+
+You can join videochat in:
+`https://YOUR-IP-ADDRESS:PORT/NAME-OF-ROOM`, for example [here](https://localhost:8443/room). You should see
+video stream from your and every other peer cameras.
+
+_You might be asked to grant access to your camera, as some operating systems require that._
+
+_In case of the absence of a physical camera, it is necessary to use a virtual camera (e.g. OBS, [see how to set up the virtual camera in OBS](https://obsproject.com/kb/virtual-camera-guide))_
+
+</details>
+
+<details>
+<summary>
+<b>Arch</b>
+</summary>
+
+### Prerequisites
+
+Make sure you have Elixir installed on your machine. For installation details, see: https://elixir-lang.org/install.html
+
+### Running the demo
+
+To run the demo, clone the `membrane_demo` repository and checkout to the demo directory:
+
+```shell
+git clone https://github.com/membraneframework/membrane_demo
+cd membrane_demo/webrtc_simple
+```
+
+Custom ip, port or other Plug options can be set up in `config/config.exs`.
+
+Then you need to download the dependencies of the mix project:
+
+```shell
+mix deps.get
+```
+
+You may be asked to install `Hex` and then `rebar3`.
+
+#### HTTPS
+
+Since application uses HTTPS, certificate and key are needed to run it. You generate them with
+
+```shell
+openssl req -newkey rsa:2048 -nodes -keyout priv/certs/key.pem -x509 -days 365 -out priv/certs/certificate.pem
+```
+
+Note that this certificate is not validated and thus may cause warnings in browser.
+
+To trust self-signed certificate follow instructions below:
+
+```shell
+trust anchor --store priv/certs/certificate.pem
+```
+
+### Usage
+
+Run application with:
+
+```shell
+mix start
+```
+
+You can join videochat in:
+`https://YOUR-IP-ADDRESS:PORT/NAME-OF-ROOM`, for example [here](https://localhost:8443/room). You should see
+video stream from your and every other peer cameras.
+
+_You might be asked to grant access to your camera, as some operating systems require that._
+
+_In case of the absence of a physical camera, it is necessary to use a virtual camera (e.g. OBS, [see how to set up the virtual camera in OBS](https://obsproject.com/kb/virtual-camera-guide))_
+
+</details>
 
 ## Copyright and License
 

--- a/webrtc_simple/README.md
+++ b/webrtc_simple/README.md
@@ -1,6 +1,6 @@
-# Membrane Demo - WebRTC Singaling Server
+# Membrane Demo - WebRTC Signaling Server
 
-Simple example of signaling server based on `Membrane.WebRTC.Server`.
+A simple example of a signaling server based on `Membrane.WebRTC.Server`.
 
 ## Prerequisites and running the demo
 
@@ -24,7 +24,7 @@ git clone https://github.com/membraneframework/membrane_demo
 cd membrane_demo/webrtc_simple
 ```
 
-Custom ip, port or other Plug options can be set up in `config/config.exs`.
+Custom IP, port, or other Plug options can be set up in `config/config.exs`.
 
 Then you need to download the dependencies of the mix project:
 
@@ -36,34 +36,34 @@ You may be asked to install `Hex` and then `rebar3`.
 
 #### HTTPS
 
-Since application uses HTTPS, certificate and key are needed to run it. You generate them with
+Since the application uses HTTPS, a certificate and key are needed to run it. You generate them with
 
 ```shell
 openssl req -newkey rsa:2048 -nodes -keyout priv/certs/key.pem -x509 -days 365 -out priv/certs/certificate.pem
 ```
 
-Note that this certificate is not validated and thus may cause warnings in browser.
+Note that this certificate is not validated and thus may cause warnings in the browser.
 
-To trust self-signed certificate follow instructions below:
+To trust the self-signed certificate follow the instructions below:
 
 ```shell
 security import priv/certs/certificate.pem -k ~/Library/Keychains/login.keychain-db
 ```
 
-Then, find your certificate in Keychains, open it, expand the Trust section and change
+Then, find your certificate in Keychains, open it, expand the Trust section, and change
 the SSL setting to "Always Trust".
 
 ### Usage
 
-Run application with:
+Run the application with:
 
 ```shell
 mix start
 ```
 
-You can join videochat in:
+You can join the videochat in:
 `https://YOUR-IP-ADDRESS:PORT/NAME-OF-ROOM`, for example [here](https://localhost:8443/room). You should see
-video stream from your and every other peer cameras.
+the video stream from your and every other peer's cameras.
 
 _You might be asked to grant access to your camera, as some operating systems require that._
 
@@ -91,7 +91,7 @@ git clone https://github.com/membraneframework/membrane_demo
 cd membrane_demo/webrtc_simple
 ```
 
-Custom ip, port or other Plug options can be set up in `config/config.exs`.
+Custom IP, port, or other Plug options can be set up in `config/config.exs`.
 
 Then you need to download the dependencies of the mix project:
 
@@ -109,15 +109,15 @@ You may be asked to install `Hex` and then `rebar3`.
 
 #### HTTPS
 
-Since application uses HTTPS, certificate and key are needed to run it. You generate them with
+Since the application uses HTTPS, a certificate and key are needed to run it. You generate them with
 
 ```shell
 openssl req -newkey rsa:2048 -nodes -keyout priv/certs/key.pem -x509 -days 365 -out priv/certs/certificate.pem
 ```
 
-Note that this certificate is not validated and thus may cause warnings in browser.
+Note that this certificate is not validated and thus may cause warnings in the browser.
 
-To trust self-signed certificate follow instructions below:
+To trust the self-signed certificate follow the instructions below:
 
 ```shell
 apt install ca-certificates
@@ -127,15 +127,15 @@ update-ca-certificates
 
 ### Usage
 
-Run application with:
+Run the application with:
 
 ```shell
 mix start
 ```
 
-You can join videochat in:
+You can join the videochat in:
 `https://YOUR-IP-ADDRESS:PORT/NAME-OF-ROOM`, for example [here](https://localhost:8443/room). You should see
-video stream from your and every other peer cameras.
+the video stream from your and every other peer's cameras.
 
 _You might be asked to grant access to your camera, as some operating systems require that._
 
@@ -161,7 +161,7 @@ git clone https://github.com/membraneframework/membrane_demo
 cd membrane_demo/webrtc_simple
 ```
 
-Custom ip, port or other Plug options can be set up in `config/config.exs`.
+Custom IP, port, or other Plug options can be set up in `config/config.exs`.
 
 Then you need to download the dependencies of the mix project:
 
@@ -173,15 +173,15 @@ You may be asked to install `Hex` and then `rebar3`.
 
 #### HTTPS
 
-Since application uses HTTPS, certificate and key are needed to run it. You generate them with
+Since the application uses HTTPS, a certificate and key are needed to run it. You generate them with
 
 ```shell
 openssl req -newkey rsa:2048 -nodes -keyout priv/certs/key.pem -x509 -days 365 -out priv/certs/certificate.pem
 ```
 
-Note that this certificate is not validated and thus may cause warnings in browser.
+Note that this certificate is not validated and thus may cause warnings in the browser.
 
-To trust self-signed certificate follow instructions below:
+To trust the self-signed certificate follow the instructions below:
 
 ```shell
 trust anchor --store priv/certs/certificate.pem
@@ -189,15 +189,15 @@ trust anchor --store priv/certs/certificate.pem
 
 ### Usage
 
-Run application with:
+Run the application with:
 
 ```shell
 mix start
 ```
 
-You can join videochat in:
+You can join the videochat in:
 `https://YOUR-IP-ADDRESS:PORT/NAME-OF-ROOM`, for example [here](https://localhost:8443/room). You should see
-video stream from your and every other peer cameras.
+the video stream from your and every other peer's cameras.
 
 _You might be asked to grant access to your camera, as some operating systems require that._
 

--- a/webrtc_to_hls/.gitignore
+++ b/webrtc_to_hls/.gitignore
@@ -32,5 +32,5 @@ videoroom-*.tar
 node_modules
 output/*
 
-# MacOS
+# macOS
 .DS_Store

--- a/webrtc_to_hls/README.md
+++ b/webrtc_to_hls/README.md
@@ -6,19 +6,24 @@ This demo is responsible for:
 - transporting media streams via WebRTC to a membrane pipeline
 - dumping received streams to a HLS stream that can be further accessed either by a displayed URL or played via an embedded HLS player
 
-## Prerequisites
+## Prerequisites and running the demo
+
+Below is the instruction for the installation of required dependencies and how to run this demo on various operating systems:
+
+<details>
+<summary>
+<b>macOS Intel</b>
+</summary>
+
+### Prerequisites
 
 Make sure you have `node.js`, `openssl`, `FFmpeg 4.*` and `srtp` installed on your computer.
-
-### Mac OS X
 
 ```shell
 brew install srtp ffmpeg opus fdk-aac openssl pkg-config
 ```
 
 Then add the following environment variables to your shell (`~/.zshrc`):
-
-#### Intel processor
 
 ```shell
 export LDFLAGS="-L/usr/local/opt/openssl@1.1lib"
@@ -27,27 +32,9 @@ export CPPFLAGS="-I/usr/local/opt/openssl@1.1/include/"
 export PKG_CONFIG_PATH="/usr/local/opt/openssl@1.1/lib/pkgconfig"
 ```
 
-#### (M1/M2) Apple Silicon processor
-
-```shell
-export C_INCLUDE_PATH="/opt/homebrew/Cellar/libnice/0.1.18/include:/opt/homebrew/Cellar/opus/1.4/include:/opt/homebrew/Cellar/openssl@1.1/1.1.1l_1/include"
-export PKG_CONFIG_PATH="/opt/homebrew/Cellar/openssl@1.1/1.1.1u/lib/pkgconfig
-export LDFLAGS="-L/opt/homebrew/Cellar/openssl@1.1/1.1.1u/lib"
-export CFLAGS="-I/opt/homebrew/Cellar/openssl@1.1/1.1.1u/include"
-export CPPFLAGS="-I/opt/homebrew/Cellar/openssl@1.1/1.1.1u/include"
-```
-
-### Ubuntu
-
-```shell
-sudo apt-get install libsrtp2-dev libavcodec-dev libavformat-dev libavutil-dev libopus-dev libfdk-aac-dev libssl-dev
-```
-
 Furthermore, make sure you have Elixir installed on your machine. For installation details, see: https://elixir-lang.org/install.html
 
-On Ubuntu, we recommend installation through `asdf`, see: https://asdf-vm.com/guide/getting-started.html
-
-## Running the demo
+### Running the demo
 
 To run the demo, clone the `membrane_demo` repository and checkout to the demo directory:
 
@@ -66,11 +53,6 @@ npm ci --prefix=assets
 ```
 
 You may be asked to install `Hex` and then `rebar3`.
-In case of installation issues with Hex on Ubuntu, try updating the system packages first by entering the command:
-
-```shell
-sudo apt-get update
-```
 
 In order to run the demo, type:
 
@@ -83,6 +65,124 @@ Then, go to <https://localhost:4000/>.
 _You might be asked to grant access to your camera, as some operating systems require that._
 
 _In case of the absence of a physical camera, it is necessary to use a virtual camera (e.g. OBS, [see how to set up the virtual camera in OBS](https://obsproject.com/kb/virtual-camera-guide))_
+
+</details>
+
+<details>
+<summary>
+<b>macOS M1/M2</b>
+</summary>
+
+### Prerequisites
+
+Make sure you have `node.js`, `openssl`, `FFmpeg 4.*` and `srtp` installed on your computer.
+
+```shell
+brew install srtp ffmpeg opus fdk-aac openssl pkg-config
+```
+
+Then add the following environment variables to your shell (`~/.zshrc`):
+
+```shell
+export C_INCLUDE_PATH="/opt/homebrew/Cellar/libnice/0.1.18/include:/opt/homebrew/Cellar/opus/1.4/include:/opt/homebrew/Cellar/openssl@1.1/1.1.1l_1/include"
+export PKG_CONFIG_PATH="/opt/homebrew/Cellar/openssl@1.1/1.1.1u/lib/pkgconfig
+export LDFLAGS="-L/opt/homebrew/Cellar/openssl@1.1/1.1.1u/lib"
+export CFLAGS="-I/opt/homebrew/Cellar/openssl@1.1/1.1.1u/include"
+export CPPFLAGS="-I/opt/homebrew/Cellar/openssl@1.1/1.1.1u/include"
+```
+
+Furthermore, make sure you have Elixir installed on your machine. For installation details, see: https://elixir-lang.org/install.html
+
+### Running the demo
+
+To run the demo, clone the `membrane_demo` repository and checkout to the demo directory:
+
+```shell
+git clone https://github.com/membraneframework/membrane_demo
+cd membrane_demo/webrtc_to_hls
+```
+
+Firstly, generate certificate, as described in the [signaling server readme](https://github.com/membraneframework/membrane_demo/webrtc_simple).
+
+Then you need to download the dependencies of the mix project:
+
+```shell
+mix deps.get
+npm ci --prefix=assets
+```
+
+You may be asked to install `Hex` and then `rebar3`.
+
+In order to run the demo, type:
+
+```shell
+mix phx.server
+```
+
+Then, go to <https://localhost:4000/>.
+
+_You might be asked to grant access to your camera, as some operating systems require that._
+
+_In case of the absence of a physical camera, it is necessary to use a virtual camera (e.g. OBS, [see how to set up the virtual camera in OBS](https://obsproject.com/kb/virtual-camera-guide))_
+
+</details>
+
+<details>
+<summary>
+<b>Ubuntu</b>
+</summary>
+
+### Prerequisites
+
+Make sure you have `node.js`, `openssl`, `FFmpeg 4.*` and `srtp` installed on your computer.
+
+```shell
+sudo apt-get install libsrtp2-dev libavcodec-dev libavformat-dev libavutil-dev libopus-dev libfdk-aac-dev libssl-dev
+```
+
+Furthermore, make sure you have Elixir installed on your machine. For installation details, see: https://elixir-lang.org/install.html
+
+On Ubuntu, we recommend installation through `asdf`, see: https://asdf-vm.com/guide/getting-started.html
+
+### Running the demo
+
+To run the demo, clone the `membrane_demo` repository and checkout to the demo directory:
+
+```shell
+git clone https://github.com/membraneframework/membrane_demo
+cd membrane_demo/webrtc_to_hls
+```
+
+Firstly, generate certificate, as described in the [signaling server readme](https://github.com/membraneframework/membrane_demo/webrtc_simple).
+
+Then you need to download the dependencies of the mix project:
+
+```shell
+mix deps.get
+npm ci --prefix=assets
+```
+
+You may be asked to install `Hex` and then `rebar3`.
+
+> In case of installation issues with Hex on Ubuntu, try updating the system packages first by entering the command:
+>
+> ```shell
+> sudo apt-get update
+> ```
+
+In order to run the demo, type:
+
+```shell
+mix phx.server
+```
+
+Then, go to <https://localhost:4000/>.
+
+_You might be asked to grant access to your camera, as some operating systems require that._
+
+_In case of the absence of a physical camera, it is necessary to use a virtual camera (e.g. OBS, [see how to set up the virtual camera in OBS](https://obsproject.com/kb/virtual-camera-guide))_
+
+</details>
 
 ## Copyright and License
 

--- a/webrtc_to_hls/README.md
+++ b/webrtc_to_hls/README.md
@@ -8,7 +8,7 @@ This demo is responsible for:
 
 ## Prerequisites
 
-Make sure you have `node.js`, `openssl`, `FFmpeg` and `srtp` installed on your computer.
+Make sure you have `node.js`, `openssl`, `FFmpeg 4.*` and `srtp` installed on your computer.
 
 ### Mac OS X
 

--- a/webrtc_to_hls/README.md
+++ b/webrtc_to_hls/README.md
@@ -2,9 +2,9 @@
 
 This demo is responsible for:
 
-- serving a phoenix app that will capture your camera and microphone
+- serving a Phoenix app that will capture your camera and microphone
 - transporting media streams via WebRTC to a membrane pipeline
-- dumping received streams to a HLS stream that can be further accessed either by a displayed URL or played via an embedded HLS player
+- dumping received streams to an HLS stream that can be further accessed either by a displayed URL or played via an embedded HLS player
 
 ## Prerequisites and running the demo
 
@@ -17,7 +17,7 @@ Below is the instruction for the installation of required dependencies and how t
 
 ### Prerequisites
 
-Make sure you have `node.js`, `openssl`, `FFmpeg 4.*` and `srtp` installed on your computer.
+Make sure you have `node.js`, `openssl`, `FFmpeg 4.*`, and `srtp` installed on your computer.
 
 ```shell
 brew install srtp ffmpeg opus fdk-aac openssl pkg-config
@@ -45,7 +45,7 @@ git clone https://github.com/membraneframework/membrane_demo
 cd membrane_demo/webrtc_to_hls
 ```
 
-Firstly, generate certificate, as described in the [signaling server readme](https://github.com/membraneframework/membrane_demo/webrtc_simple).
+Firstly, generate a certificate, as described in the [signaling server readme](https://github.com/membraneframework/membrane_demo/webrtc_simple).
 
 Then you need to download the dependencies of the mix project:
 
@@ -56,7 +56,7 @@ npm ci --prefix=assets
 
 You may be asked to install `Hex` and then `rebar3`.
 
-In order to run the demo, type:
+To run the demo, type:
 
 ```shell
 mix phx.server
@@ -77,7 +77,7 @@ _In case of the absence of a physical camera, it is necessary to use a virtual c
 
 ### Prerequisites
 
-Make sure you have `node.js`, `openssl`, `FFmpeg 4.*` and `srtp` installed on your computer.
+Make sure you have `node.js`, `openssl`, `FFmpeg 4.*`, and `srtp` installed on your computer.
 
 ```shell
 brew install srtp ffmpeg opus fdk-aac openssl pkg-config
@@ -106,7 +106,7 @@ git clone https://github.com/membraneframework/membrane_demo
 cd membrane_demo/webrtc_to_hls
 ```
 
-Firstly, generate certificate, as described in the [signaling server readme](https://github.com/membraneframework/membrane_demo/webrtc_simple).
+Firstly, generate a certificate, as described in the [signaling server readme](https://github.com/membraneframework/membrane_demo/webrtc_simple).
 
 Then you need to download the dependencies of the mix project:
 
@@ -117,7 +117,7 @@ npm ci --prefix=assets
 
 You may be asked to install `Hex` and then `rebar3`.
 
-In order to run the demo, type:
+To run the demo, type:
 
 ```shell
 mix phx.server
@@ -138,7 +138,7 @@ _In case of the absence of a physical camera, it is necessary to use a virtual c
 
 ### Prerequisites
 
-Make sure you have `node.js`, `openssl`, `FFmpeg 4.*` and `srtp` installed on your computer.
+Make sure you have `node.js`, `openssl`, `FFmpeg 4.*`, and `srtp` installed on your computer.
 
 ```shell
 sudo apt-get install libsrtp2-dev libavcodec-dev libavformat-dev libavutil-dev libopus-dev libfdk-aac-dev libssl-dev
@@ -157,7 +157,7 @@ git clone https://github.com/membraneframework/membrane_demo
 cd membrane_demo/webrtc_to_hls
 ```
 
-Firstly, generate certificate, as described in the [signaling server readme](https://github.com/membraneframework/membrane_demo/webrtc_simple).
+Firstly, generate a certificate, as described in the [signaling server readme](https://github.com/membraneframework/membrane_demo/webrtc_simple).
 
 Then you need to download the dependencies of the mix project:
 
@@ -174,7 +174,7 @@ You may be asked to install `Hex` and then `rebar3`.
 > sudo apt-get update
 > ```
 
-In order to run the demo, type:
+To run the demo, type:
 
 ```shell
 mix phx.server

--- a/webrtc_to_hls/README.md
+++ b/webrtc_to_hls/README.md
@@ -1,40 +1,89 @@
 # Membrane WebRTC To HLS demo
 
 This demo is responsible for:
-* serving a phoenix app that will capture your camera and microphone
-* transporting media streams via WebRTC to a membrane pipeline
-* dumping received streams to a HLS stream that can be further accessed either by a displayed URL or played via an embedded HLS player
 
-## Dependencies
+- serving a phoenix app that will capture your camera and microphone
+- transporting media streams via WebRTC to a membrane pipeline
+- dumping received streams to a HLS stream that can be further accessed either by a displayed URL or played via an embedded HLS player
+
+## Prerequisites
+
+Make sure you have `node.js`, `openssl`, `ffmpeg` and `srtp` installed on your computer.
 
 ### Mac OS X
 
 ```
-brew install srtp ffmpeg opus fdk-aac
+brew install srtp ffmpeg opus fdk-aac openssl pkg-config
+```
+
+Then add the following environment variables to your shell (`~/.zshrc`):
+
+#### Intel processor
+
+```
+export LDFLAGS="-L/usr/local/opt/openssl@1.1lib"
+export CFLAGS="-I/usr/local/opt/openssl@1.1/include/"
+export CPPFLAGS="-I/usr/local/opt/openssl@1.1/include/"
+export PKG_CONFIG_PATH="/usr/local/opt/openssl@1.1/lib/pkgconfig"
+```
+
+#### (M1/M2) Apple Silicon processor
+
+```
+export C_INCLUDE_PATH="/opt/homebrew/Cellar/libnice/0.1.18/include:/opt/homebrew/Cellar/opus/1.4/include:/opt/homebrew/Cellar/openssl@1.1/1.1.1l_1/include"
+export PKG_CONFIG_PATH="/opt/homebrew/Cellar/openssl@1.1/1.1.1u/lib/pkgconfig
+export LDFLAGS="-L/opt/homebrew/Cellar/openssl@1.1/1.1.1u/lib"
+export CFLAGS="-I/opt/homebrew/Cellar/openssl@1.1/1.1.1u/include"
+export CPPFLAGS="-I/opt/homebrew/Cellar/openssl@1.1/1.1.1u/include"
 ```
 
 ### Ubuntu
 
 ```
-sudo apt-get install libsrtp2-dev libavcodec-dev libavformat-dev libavutil-dev libopus-dev libfdk-aac-dev
+sudo apt-get install libsrtp2-dev libavcodec-dev libavformat-dev libavutil-dev libopus-dev libfdk-aac-dev libssl-dev
 ```
 
-## Usage
+Furthermore, make sure you have Elixir installed on your machine. For installation details, see: https://elixir-lang.org/install.html
 
-Firstly, generate certificate, as described in the [signaling server readme](https://github.com/membraneframework/membrane_demo/tree/master/webrtc/simple#https). 
+On Ubuntu, we recommend installation through asdf, see: https://asdf-vm.com/guide/getting-started.html
 
-Install all dependencies:
+## Running the demo
+
+To run the demo, clone the `membrane_demo` repository and checkout to the demo directory:
+
+```console
+git clone https://github.com/membraneframework/membrane_demo
+cd membrane_demo/webrtc_to_hls
+```
+
+Firstly, generate certificate, as described in the [signaling server readme](https://github.com/membraneframework/membrane_demo/webrtc_simple).
+
+Then you need to download the dependencies of the mix project:
+
 ```
 mix deps.get
 npm ci --prefix=assets
 ```
 
-In order to run, type:
+Then you may be asked to install `Hex` and then `rebar3`.
+
+In case of installation issues with Hex on Ubuntu, try updating the system packages first by entering the command:
+
+```shell
+sudo apt-get update
+```
+
+In order to run the demo, type:
+
 ```
 mix phx.server
 ```
 
 Then, go to <https://localhost:4000/>.
+
+_You might be asked to grant access to your camera, as some operating systems require that._
+
+_In case of the absence of a physical camera, it is necessary to use a virtual camera (e.g. OBS)._
 
 ## Copyright and License
 

--- a/webrtc_to_hls/README.md
+++ b/webrtc_to_hls/README.md
@@ -32,6 +32,8 @@ export CPPFLAGS="-I/usr/local/opt/openssl@1.1/include/"
 export PKG_CONFIG_PATH="/usr/local/opt/openssl@1.1/lib/pkgconfig"
 ```
 
+and restart your terminal.
+
 Furthermore, make sure you have Elixir installed on your machine. For installation details, see: https://elixir-lang.org/install.html
 
 ### Running the demo
@@ -90,6 +92,8 @@ export LDFLAGS="-L/opt/homebrew/Cellar/openssl@1.1/1.1.1u/lib"
 export CFLAGS="-I/opt/homebrew/Cellar/openssl@1.1/1.1.1u/include"
 export CPPFLAGS="-I/opt/homebrew/Cellar/openssl@1.1/1.1.1u/include"
 ```
+
+and restart your terminal.
 
 Furthermore, make sure you have Elixir installed on your machine. For installation details, see: https://elixir-lang.org/install.html
 

--- a/webrtc_to_hls/README.md
+++ b/webrtc_to_hls/README.md
@@ -8,11 +8,11 @@ This demo is responsible for:
 
 ## Prerequisites
 
-Make sure you have `node.js`, `openssl`, `ffmpeg` and `srtp` installed on your computer.
+Make sure you have `node.js`, `openssl`, `FFmpeg` and `srtp` installed on your computer.
 
 ### Mac OS X
 
-```
+```shell
 brew install srtp ffmpeg opus fdk-aac openssl pkg-config
 ```
 
@@ -20,7 +20,7 @@ Then add the following environment variables to your shell (`~/.zshrc`):
 
 #### Intel processor
 
-```
+```shell
 export LDFLAGS="-L/usr/local/opt/openssl@1.1lib"
 export CFLAGS="-I/usr/local/opt/openssl@1.1/include/"
 export CPPFLAGS="-I/usr/local/opt/openssl@1.1/include/"
@@ -29,7 +29,7 @@ export PKG_CONFIG_PATH="/usr/local/opt/openssl@1.1/lib/pkgconfig"
 
 #### (M1/M2) Apple Silicon processor
 
-```
+```shell
 export C_INCLUDE_PATH="/opt/homebrew/Cellar/libnice/0.1.18/include:/opt/homebrew/Cellar/opus/1.4/include:/opt/homebrew/Cellar/openssl@1.1/1.1.1l_1/include"
 export PKG_CONFIG_PATH="/opt/homebrew/Cellar/openssl@1.1/1.1.1u/lib/pkgconfig
 export LDFLAGS="-L/opt/homebrew/Cellar/openssl@1.1/1.1.1u/lib"
@@ -39,19 +39,19 @@ export CPPFLAGS="-I/opt/homebrew/Cellar/openssl@1.1/1.1.1u/include"
 
 ### Ubuntu
 
-```
+```shell
 sudo apt-get install libsrtp2-dev libavcodec-dev libavformat-dev libavutil-dev libopus-dev libfdk-aac-dev libssl-dev
 ```
 
 Furthermore, make sure you have Elixir installed on your machine. For installation details, see: https://elixir-lang.org/install.html
 
-On Ubuntu, we recommend installation through asdf, see: https://asdf-vm.com/guide/getting-started.html
+On Ubuntu, we recommend installation through `asdf`, see: https://asdf-vm.com/guide/getting-started.html
 
 ## Running the demo
 
 To run the demo, clone the `membrane_demo` repository and checkout to the demo directory:
 
-```console
+```shell
 git clone https://github.com/membraneframework/membrane_demo
 cd membrane_demo/webrtc_to_hls
 ```
@@ -60,13 +60,12 @@ Firstly, generate certificate, as described in the [signaling server readme](htt
 
 Then you need to download the dependencies of the mix project:
 
-```
+```shell
 mix deps.get
 npm ci --prefix=assets
 ```
 
-Then you may be asked to install `Hex` and then `rebar3`.
-
+You may be asked to install `Hex` and then `rebar3`.
 In case of installation issues with Hex on Ubuntu, try updating the system packages first by entering the command:
 
 ```shell
@@ -75,7 +74,7 @@ sudo apt-get update
 
 In order to run the demo, type:
 
-```
+```shell
 mix phx.server
 ```
 
@@ -83,7 +82,7 @@ Then, go to <https://localhost:4000/>.
 
 _You might be asked to grant access to your camera, as some operating systems require that._
 
-_In case of the absence of a physical camera, it is necessary to use a virtual camera (e.g. OBS)._
+_In case of the absence of a physical camera, it is necessary to use a virtual camera (e.g. OBS, [see how to set up the virtual camera in OBS](https://obsproject.com/kb/virtual-camera-guide))_
 
 ## Copyright and License
 

--- a/webrtc_to_hls/lib/webrtc_to_hls_web/endpoint.ex
+++ b/webrtc_to_hls/lib/webrtc_to_hls_web/endpoint.ex
@@ -24,7 +24,7 @@ defmodule WebRTCToHLSWeb.Endpoint do
     parsers: [
       :urlencoded,
       :multipart,
-      :json,
+      :json
     ],
     pass: ["*/*"],
     json_decoder: Phoenix.json_library()

--- a/webrtc_to_hls/lib/webrtc_to_hls_web/endpoint.ex
+++ b/webrtc_to_hls/lib/webrtc_to_hls_web/endpoint.ex
@@ -25,7 +25,6 @@ defmodule WebRTCToHLSWeb.Endpoint do
       :urlencoded,
       :multipart,
       :json,
-      Absinthe.Plug.Parser
     ],
     pass: ["*/*"],
     json_decoder: Phoenix.json_library()

--- a/webrtc_videoroom/.gitignore
+++ b/webrtc_videoroom/.gitignore
@@ -32,5 +32,5 @@ videoroom-*.tar
 
 node_modules
 
-# MacOS
+# macOS
 .DS_Store

--- a/webrtc_videoroom/README.md
+++ b/webrtc_videoroom/README.md
@@ -13,7 +13,7 @@ Below is the instruction for the installation of required dependencies and how t
 
 ### Prerequisites
 
-Make sure you have `node.js`, `openssl`, `FFmpeg` and `srtp` installed on your computer.
+Make sure you have `node.js`, `openssl`, `FFmpeg`, and `srtp` installed on your computer.
 
 ```shell
 brew install srtp libnice clang-format ffmpeg opus openssl pkg-config
@@ -50,7 +50,7 @@ npm ci --prefix=assets
 
 You may be asked to install `Hex` and then `rebar3`.
 
-In order to run the demo, type:
+To run the demo, type:
 
 ```shell
 EXTERNAL_IP=<IPv4 address> mix phx.server
@@ -92,7 +92,7 @@ _In case of the absence of a physical camera, it is necessary to use a virtual c
 
 ### Prerequisites
 
-Make sure you have `node.js`, `openssl`, `FFmpeg` and `srtp` installed on your computer.
+Make sure you have `node.js`, `openssl`, `FFmpeg`, and `srtp` installed on your computer.
 
 ```shell
 brew install srtp libnice clang-format ffmpeg opus openssl pkg-config
@@ -130,7 +130,7 @@ npm ci --prefix=assets
 
 You may be asked to install `Hex` and then `rebar3`.
 
-In order to run the demo, type:
+To run the demo, type:
 
 ```shell
 EXTERNAL_IP=<IPv4 address> mix phx.server
@@ -172,7 +172,7 @@ _In case of the absence of a physical camera, it is necessary to use a virtual c
 
 ### Prerequisites
 
-Make sure you have `node.js`, `openssl`, `FFmpeg` and `srtp` installed on your computer.
+Make sure you have `node.js`, `openssl`, `FFmpeg`, and `srtp` installed on your computer.
 
 ```shell
 sudo apt-get install libsrtp2-dev libnice-dev libavcodec-dev libavformat-dev libavutil-dev libopus-dev libssl-dev
@@ -206,7 +206,7 @@ You may be asked to install `Hex` and then `rebar3`.
 > sudo apt-get update
 > ```
 
-In order to run the demo, type:
+To run the demo, type:
 
 ```shell
 EXTERNAL_IP=<IPv4 address> mix phx.server
@@ -243,7 +243,7 @@ _In case of the absence of a physical camera, it is necessary to use a virtual c
 
 ## Run with docker
 
-Videoroom demo provides a `Dockerfile` that you can use to run videoroom application yourself without any additional setup and dependencies.
+The Videoroom demo provides a `Dockerfile` that you can use to run the Videoroom application yourself without any additional setup and dependencies.
 
 ### To run:
 
@@ -251,7 +251,7 @@ Videoroom demo provides a `Dockerfile` that you can use to run videoroom applica
 docker run -p 4000:4000 membraneframework/demo_webrtc_videoroom:latest
 ```
 
-Or build and run docker image from source:
+Or build and run a docker image from the source:
 
 ```shell
 docker build  -t membrane_videoroom .
@@ -268,7 +268,7 @@ Then go to <http://localhost:4000/>.
 
 ## Run distributed
 
-Videoroom demo does not automatically start a cluster, but you can check the distributed functionalities by starting one manually.
+The Videoroom demo does not automatically start a cluster, but you can check the distributed functionalities by starting one manually.
 
 Open two terminals. On the first run:
 
@@ -300,7 +300,7 @@ iex(one@{your-local-hostname})2> :erlang.nodes()
 ```
 
 Then, open two tabs on your browser. Go to <http://localhost:4001/> on one, and <http://localhost:4002/> on the other.
-Join the same room, and you shall see two participants in the room. Every participant EndPoint will be running on their respective node.
+Join the same room, and you shall see two participants in the room. Every participant's EndPoint will be running on their respective node.
 
 _You might be asked to grant access to your camera, as some operating systems require that._
 

--- a/webrtc_videoroom/README.md
+++ b/webrtc_videoroom/README.md
@@ -4,39 +4,99 @@ This project demonstrates an example usage of Membrane SFU API defined in [membr
 
 ## Run manually
 
-### Dependencies
+### Prerequisites
 
-In order to run phoenix application manually you will need to have `node` installed.
-Demo has been tested with `node` version `v14.15.0`. You will also need some system dependencies.
+Make sure you have `node.js`, `openssl`, `ffmpeg` and `srtp` installed on your computer.
 
 #### Mac OS X
 
 ```
-brew install srtp libnice clang-format ffmpeg opus
+brew install srtp libnice clang-format ffmpeg opus openssl pkg-config
+```
+
+Then add the following environment variables to your shell (`~/.zshrc`):
+
+#### Intel processor
+
+```
+export LDFLAGS="-L/usr/local/opt/openssl@1.1lib"
+export CFLAGS="-I/usr/local/opt/openssl@1.1/include/"
+export CPPFLAGS="-I/usr/local/opt/openssl@1.1/include/"
+export PKG_CONFIG_PATH="/usr/local/opt/openssl@1.1/lib/pkgconfig"
+```
+
+#### (M1/M2) Apple Silicon processor
+
+```
+export C_INCLUDE_PATH="/opt/homebrew/Cellar/libnice/0.1.18/include:/opt/homebrew/Cellar/opus/1.4/include:/opt/homebrew/Cellar/openssl@1.1/1.1.1l_1/include"
+export PKG_CONFIG_PATH="/opt/homebrew/Cellar/openssl@1.1/1.1.1u/lib/pkgconfig
+export LDFLAGS="-L/opt/homebrew/Cellar/openssl@1.1/1.1.1u/lib"
+export CFLAGS="-I/opt/homebrew/Cellar/openssl@1.1/1.1.1u/include"
+export CPPFLAGS="-I/opt/homebrew/Cellar/openssl@1.1/1.1.1u/include"
 ```
 
 #### Ubuntu
 
 ```
-sudo apt-get install libsrtp2-dev libnice-dev libavcodec-dev libavformat-dev libavutil-dev libopus-dev
+sudo apt-get install libsrtp2-dev libnice-dev libavcodec-dev libavformat-dev libavutil-dev libopus-dev libssl-dev
 ```
 
-### To run
-First install all dependencies:
+Furthermore, make sure you have Elixir installed on your machine. For installation details, see: https://elixir-lang.org/install.html
+
+On Ubuntu, we recommend installation through asdf, see: https://asdf-vm.com/guide/getting-started.html
+
+### Running the demo
+
+To run the demo, clone the `membrane_demo` repository and checkout to the demo directory:
+
+```console
+git clone https://github.com/membraneframework/membrane_demo
+cd membrane_demo/webrtc_videoroom
+```
+
+Then you need to download the dependencies of the mix project:
+
 ```
 mix deps.get
 npm ci --prefix=assets
 ```
 
-In order to run, type:
+Then you may be asked to install `Hex` and then `rebar3`.
+
+In case of installation issues with Hex on Ubuntu, try updating the system packages first by entering the command:
+
+```shell
+sudo apt-get update
+```
+
+In order to run the demo, type:
 
 ```
-EXTERNAL_IP=<IPv4 address> mix phx.server 
+
+EXTERNAL_IP=<IPv4 address> mix phx.server
+
 ```
+
 where:
-* `EXTERNAL_IP` - your local IPv4 address (not to be confused with loopback)
 
-[Instructions on how to find your IPv4 address](https://github.com/membraneframework/membrane_videoroom#launching-of-the-application-1)
+- `EXTERNAL_IP` - your local IPv4 address of the computer this is running on. It is required unless you only connect via localhost (not to be confused with loopback).
+
+To make the server available from your local network, you can set it to a private address, like 192.168._._. The address can be found with the use of the `ifconfig` command:
+
+```
+ifconfig
+...
+en0: flags=8863<UP,BROADCAST,SMART,RUNNING,SIMPLEX,MULTICAST> mtu 1500
+ options=400<CHANNEL_IO>
+ ether 88:66:5a:49:ac:e0
+ inet6 fe80::426:8833:1408:cd1a%en0 prefixlen 64 secured scopeid 0x6
+ inet 192.168.1.196 netmask 0xffffff00 broadcast 192.168.1.255
+ nd6 options=201<PERFORMNUD,DAD>
+ media: autoselect
+ status: active
+```
+
+(The address we are seeking is the address following the inet field - in that particular case, 192.168.1.196)
 
 Then go to <http://localhost:4000/>.
 
@@ -51,13 +111,15 @@ docker run -p 4000:4000 membraneframework/demo_webrtc_videoroom:latest
 ```
 
 Or build and run docker image from source:
+
 ```bash
 docker build  -t membrane_videoroom .
 docker run -p 50000-50050:50000-50050/udp -p 4000:4000/tcp -e PORT_RANGE=50000-50050 -e EXTERNAL_IP=<IPv4 address> membrane_videoroom
 ```
 
 where:
-* `EXTERNAL_IP` - your local IPv4 address (not to be confused with loopback)
+
+- `EXTERNAL_IP` - your local IPv4 address (not to be confused with loopback)
 
 [Instructions on how to find your IPv4 address](https://github.com/membraneframework/membrane_videoroom#launching-of-the-application-1)
 
@@ -92,12 +154,16 @@ true
 You can check that the cluster has been created with:
 
 ```elixir
-iex(one@{your-local-hostname})2> :erlang.nodes()                     
+iex(one@{your-local-hostname})2> :erlang.nodes()
 [:two@{your-local-hostname}]
 ```
 
 Then, open two tabs on your browser. Go to <http://localhost:4001/> on one, and <http://localhost:4002/> on the other.
 Join the same room, and you shall see two participants in the room. Every participant EndPoint will be running on their respective node.
+
+_You might be asked to grant access to your camera, as some operating systems require that._
+
+_In case of the absence of a physical camera, it is necessary to use a virtual camera (e.g. OBS)._
 
 ## Copyright and License
 

--- a/webrtc_videoroom/README.md
+++ b/webrtc_videoroom/README.md
@@ -4,19 +4,22 @@ This project demonstrates an example usage of Membrane SFU API defined in [membr
 
 ## Run manually
 
+Below is the instruction for the installation of required dependencies and how to run this demo on various operating systems:
+
+<details>
+<summary>
+<b>macOS Intel</b>
+</summary>
+
 ### Prerequisites
 
 Make sure you have `node.js`, `openssl`, `FFmpeg` and `srtp` installed on your computer.
-
-#### Mac OS X
 
 ```shell
 brew install srtp libnice clang-format ffmpeg opus openssl pkg-config
 ```
 
 Then add the following environment variables to your shell (`~/.zshrc`):
-
-#### Intel processor
 
 ```shell
 export LDFLAGS="-L/usr/local/opt/openssl@1.1lib"
@@ -25,25 +28,7 @@ export CPPFLAGS="-I/usr/local/opt/openssl@1.1/include/"
 export PKG_CONFIG_PATH="/usr/local/opt/openssl@1.1/lib/pkgconfig"
 ```
 
-#### (M1/M2) Apple Silicon processor
-
-```shell
-export C_INCLUDE_PATH="/opt/homebrew/Cellar/libnice/0.1.18/include:/opt/homebrew/Cellar/opus/1.4/include:/opt/homebrew/Cellar/openssl@1.1/1.1.1l_1/include"
-export PKG_CONFIG_PATH="/opt/homebrew/Cellar/openssl@1.1/1.1.1u/lib/pkgconfig"
-export LDFLAGS="-L/opt/homebrew/Cellar/openssl@1.1/1.1.1u/lib"
-export CFLAGS="-I/opt/homebrew/Cellar/openssl@1.1/1.1.1u/include"
-export CPPFLAGS="-I/opt/homebrew/Cellar/openssl@1.1/1.1.1u/include"
-```
-
-#### Ubuntu
-
-```shell
-sudo apt-get install libsrtp2-dev libnice-dev libavcodec-dev libavformat-dev libavutil-dev libopus-dev libssl-dev
-```
-
 Furthermore, make sure you have Elixir installed on your machine. For installation details, see: https://elixir-lang.org/install.html
-
-On Ubuntu, we recommend installation through `asdf`, see: https://asdf-vm.com/guide/getting-started.html
 
 ### Running the demo
 
@@ -62,11 +47,6 @@ npm ci --prefix=assets
 ```
 
 You may be asked to install `Hex` and then `rebar3`.
-In case of installation issues with Hex on Ubuntu, try updating the system packages first by entering the command:
-
-```shell
-sudo apt-get update
-```
 
 In order to run the demo, type:
 
@@ -96,6 +76,166 @@ en0: flags=8863<UP,BROADCAST,SMART,RUNNING,SIMPLEX,MULTICAST> mtu 1500
 (The address we are seeking is the address following the inet field - in that particular case, 192.168.1.196)
 
 Then go to <http://localhost:4000/>.
+
+_You might be asked to grant access to your camera, as some operating systems require that._
+
+_In case of the absence of a physical camera, it is necessary to use a virtual camera (e.g. OBS, [see how to set up the virtual camera in OBS](https://obsproject.com/kb/virtual-camera-guide))_
+
+</details>
+
+<details>
+<summary>
+<b>macOS M1/M2</b>
+</summary>
+
+### Prerequisites
+
+Make sure you have `node.js`, `openssl`, `FFmpeg` and `srtp` installed on your computer.
+
+```shell
+brew install srtp libnice clang-format ffmpeg opus openssl pkg-config
+```
+
+Then add the following environment variables to your shell (`~/.zshrc`):
+
+```shell
+export C_INCLUDE_PATH="/opt/homebrew/Cellar/libnice/0.1.18/include:/opt/homebrew/Cellar/opus/1.4/include:/opt/homebrew/Cellar/openssl@1.1/1.1.1l_1/include"
+export PKG_CONFIG_PATH="/opt/homebrew/Cellar/openssl@1.1/1.1.1u/lib/pkgconfig"
+export LDFLAGS="-L/opt/homebrew/Cellar/openssl@1.1/1.1.1u/lib"
+export CFLAGS="-I/opt/homebrew/Cellar/openssl@1.1/1.1.1u/include"
+export CPPFLAGS="-I/opt/homebrew/Cellar/openssl@1.1/1.1.1u/include"
+```
+
+Furthermore, make sure you have Elixir installed on your machine. For installation details, see: https://elixir-lang.org/install.html
+
+### Running the demo
+
+To run the demo, clone the `membrane_demo` repository and checkout to the demo directory:
+
+```shell
+git clone https://github.com/membraneframework/membrane_demo
+cd membrane_demo/webrtc_videoroom
+```
+
+Then you need to download the dependencies of the mix project:
+
+```shell
+mix deps.get
+npm ci --prefix=assets
+```
+
+You may be asked to install `Hex` and then `rebar3`.
+
+In order to run the demo, type:
+
+```shell
+EXTERNAL_IP=<IPv4 address> mix phx.server
+```
+
+where:
+
+- `EXTERNAL_IP` - your local IPv4 address of the computer this is running on. It is required unless you only connect via localhost (not to be confused with loopback).
+
+To make the server available from your local network, you can set it to a private address, like 192.168._._. The address can be found with the use of the `ifconfig` command:
+
+```shell
+ifconfig
+...
+en0: flags=8863<UP,BROADCAST,SMART,RUNNING,SIMPLEX,MULTICAST> mtu 1500
+ options=400<CHANNEL_IO>
+ ether 88:66:5a:49:ac:e0
+ inet6 fe80::426:8833:1408:cd1a%en0 prefixlen 64 secured scopeid 0x6
+ inet 192.168.1.196 netmask 0xffffff00 broadcast 192.168.1.255
+ nd6 options=201<PERFORMNUD,DAD>
+ media: autoselect
+ status: active
+```
+
+(The address we are seeking is the address following the inet field - in that particular case, 192.168.1.196)
+
+Then go to <http://localhost:4000/>.
+
+_You might be asked to grant access to your camera, as some operating systems require that._
+
+_In case of the absence of a physical camera, it is necessary to use a virtual camera (e.g. OBS, [see how to set up the virtual camera in OBS](https://obsproject.com/kb/virtual-camera-guide))_
+
+</details>
+
+<details>
+<summary>
+<b>Ubuntu</b>
+</summary>
+
+### Prerequisites
+
+Make sure you have `node.js`, `openssl`, `FFmpeg` and `srtp` installed on your computer.
+
+```shell
+sudo apt-get install libsrtp2-dev libnice-dev libavcodec-dev libavformat-dev libavutil-dev libopus-dev libssl-dev
+```
+
+Furthermore, make sure you have Elixir installed on your machine. For installation details, see: https://elixir-lang.org/install.html
+
+On Ubuntu, we recommend installation through `asdf`, see: https://asdf-vm.com/guide/getting-started.html
+
+### Running the demo
+
+To run the demo, clone the `membrane_demo` repository and checkout to the demo directory:
+
+```shell
+git clone https://github.com/membraneframework/membrane_demo
+cd membrane_demo/webrtc_videoroom
+```
+
+Then you need to download the dependencies of the mix project:
+
+```shell
+mix deps.get
+npm ci --prefix=assets
+```
+
+You may be asked to install `Hex` and then `rebar3`.
+
+> In case of installation issues with Hex on Ubuntu, try updating the system packages first by entering the command:
+>
+> ```shell
+> sudo apt-get update
+> ```
+
+In order to run the demo, type:
+
+```shell
+EXTERNAL_IP=<IPv4 address> mix phx.server
+```
+
+where:
+
+- `EXTERNAL_IP` - your local IPv4 address of the computer this is running on. It is required unless you only connect via localhost (not to be confused with loopback).
+
+To make the server available from your local network, you can set it to a private address, like 192.168._._. The address can be found with the use of the `ifconfig` command:
+
+```shell
+ifconfig
+...
+en0: flags=8863<UP,BROADCAST,SMART,RUNNING,SIMPLEX,MULTICAST> mtu 1500
+ options=400<CHANNEL_IO>
+ ether 88:66:5a:49:ac:e0
+ inet6 fe80::426:8833:1408:cd1a%en0 prefixlen 64 secured scopeid 0x6
+ inet 192.168.1.196 netmask 0xffffff00 broadcast 192.168.1.255
+ nd6 options=201<PERFORMNUD,DAD>
+ media: autoselect
+ status: active
+```
+
+(The address we are seeking is the address following the inet field - in that particular case, 192.168.1.196)
+
+Then go to <http://localhost:4000/>.
+
+_You might be asked to grant access to your camera, as some operating systems require that._
+
+_In case of the absence of a physical camera, it is necessary to use a virtual camera (e.g. OBS, [see how to set up the virtual camera in OBS](https://obsproject.com/kb/virtual-camera-guide))_
+
+</details>
 
 ## Run with docker
 

--- a/webrtc_videoroom/README.md
+++ b/webrtc_videoroom/README.md
@@ -28,6 +28,8 @@ export CPPFLAGS="-I/usr/local/opt/openssl@1.1/include/"
 export PKG_CONFIG_PATH="/usr/local/opt/openssl@1.1/lib/pkgconfig"
 ```
 
+and restart your terminal.
+
 Furthermore, make sure you have Elixir installed on your machine. For installation details, see: https://elixir-lang.org/install.html
 
 ### Running the demo
@@ -105,6 +107,8 @@ export LDFLAGS="-L/opt/homebrew/Cellar/openssl@1.1/1.1.1u/lib"
 export CFLAGS="-I/opt/homebrew/Cellar/openssl@1.1/1.1.1u/include"
 export CPPFLAGS="-I/opt/homebrew/Cellar/openssl@1.1/1.1.1u/include"
 ```
+
+and restart your terminal.
 
 Furthermore, make sure you have Elixir installed on your machine. For installation details, see: https://elixir-lang.org/install.html
 

--- a/webrtc_videoroom/README.md
+++ b/webrtc_videoroom/README.md
@@ -6,11 +6,11 @@ This project demonstrates an example usage of Membrane SFU API defined in [membr
 
 ### Prerequisites
 
-Make sure you have `node.js`, `openssl`, `ffmpeg` and `srtp` installed on your computer.
+Make sure you have `node.js`, `openssl`, `FFmpeg` and `srtp` installed on your computer.
 
 #### Mac OS X
 
-```
+```shell
 brew install srtp libnice clang-format ffmpeg opus openssl pkg-config
 ```
 
@@ -18,7 +18,7 @@ Then add the following environment variables to your shell (`~/.zshrc`):
 
 #### Intel processor
 
-```
+```shell
 export LDFLAGS="-L/usr/local/opt/openssl@1.1lib"
 export CFLAGS="-I/usr/local/opt/openssl@1.1/include/"
 export CPPFLAGS="-I/usr/local/opt/openssl@1.1/include/"
@@ -27,9 +27,9 @@ export PKG_CONFIG_PATH="/usr/local/opt/openssl@1.1/lib/pkgconfig"
 
 #### (M1/M2) Apple Silicon processor
 
-```
+```shell
 export C_INCLUDE_PATH="/opt/homebrew/Cellar/libnice/0.1.18/include:/opt/homebrew/Cellar/opus/1.4/include:/opt/homebrew/Cellar/openssl@1.1/1.1.1l_1/include"
-export PKG_CONFIG_PATH="/opt/homebrew/Cellar/openssl@1.1/1.1.1u/lib/pkgconfig
+export PKG_CONFIG_PATH="/opt/homebrew/Cellar/openssl@1.1/1.1.1u/lib/pkgconfig"
 export LDFLAGS="-L/opt/homebrew/Cellar/openssl@1.1/1.1.1u/lib"
 export CFLAGS="-I/opt/homebrew/Cellar/openssl@1.1/1.1.1u/include"
 export CPPFLAGS="-I/opt/homebrew/Cellar/openssl@1.1/1.1.1u/include"
@@ -37,32 +37,31 @@ export CPPFLAGS="-I/opt/homebrew/Cellar/openssl@1.1/1.1.1u/include"
 
 #### Ubuntu
 
-```
+```shell
 sudo apt-get install libsrtp2-dev libnice-dev libavcodec-dev libavformat-dev libavutil-dev libopus-dev libssl-dev
 ```
 
 Furthermore, make sure you have Elixir installed on your machine. For installation details, see: https://elixir-lang.org/install.html
 
-On Ubuntu, we recommend installation through asdf, see: https://asdf-vm.com/guide/getting-started.html
+On Ubuntu, we recommend installation through `asdf`, see: https://asdf-vm.com/guide/getting-started.html
 
 ### Running the demo
 
 To run the demo, clone the `membrane_demo` repository and checkout to the demo directory:
 
-```console
+```shell
 git clone https://github.com/membraneframework/membrane_demo
 cd membrane_demo/webrtc_videoroom
 ```
 
 Then you need to download the dependencies of the mix project:
 
-```
+```shell
 mix deps.get
 npm ci --prefix=assets
 ```
 
-Then you may be asked to install `Hex` and then `rebar3`.
-
+You may be asked to install `Hex` and then `rebar3`.
 In case of installation issues with Hex on Ubuntu, try updating the system packages first by entering the command:
 
 ```shell
@@ -71,10 +70,8 @@ sudo apt-get update
 
 In order to run the demo, type:
 
-```
-
+```shell
 EXTERNAL_IP=<IPv4 address> mix phx.server
-
 ```
 
 where:
@@ -83,7 +80,7 @@ where:
 
 To make the server available from your local network, you can set it to a private address, like 192.168._._. The address can be found with the use of the `ifconfig` command:
 
-```
+```shell
 ifconfig
 ...
 en0: flags=8863<UP,BROADCAST,SMART,RUNNING,SIMPLEX,MULTICAST> mtu 1500
@@ -106,13 +103,13 @@ Videoroom demo provides a `Dockerfile` that you can use to run videoroom applica
 
 ### To run:
 
-```bash
+```shell
 docker run -p 4000:4000 membraneframework/demo_webrtc_videoroom:latest
 ```
 
 Or build and run docker image from source:
 
-```bash
+```shell
 docker build  -t membrane_videoroom .
 docker run -p 50000-50050:50000-50050/udp -p 4000:4000/tcp -e PORT_RANGE=50000-50050 -e EXTERNAL_IP=<IPv4 address> membrane_videoroom
 ```
@@ -131,13 +128,13 @@ Videoroom demo does not automatically start a cluster, but you can check the dis
 
 Open two terminals. On the first run:
 
-```bash
+```shell
 SERVER_PORT=4001 iex --sname one -S mix phx.server
 ```
 
 On the second, run:
 
-```bash
+```shell
 SERVER_PORT=4002 iex --sname two -S mix phx.server
 ```
 
@@ -163,7 +160,7 @@ Join the same room, and you shall see two participants in the room. Every partic
 
 _You might be asked to grant access to your camera, as some operating systems require that._
 
-_In case of the absence of a physical camera, it is necessary to use a virtual camera (e.g. OBS)._
+_In case of the absence of a physical camera, it is necessary to use a virtual camera (e.g. OBS, [see how to set up the virtual camera in OBS](https://obsproject.com/kb/virtual-camera-guide))_
 
 ## Copyright and License
 


### PR DESCRIPTION
Update readme files in membrane_demo to improve completeness and accuracy of all instructions for people who want to run Membrane demos. 

In all the files, the prerequisites sections were updated, descriptions regarding dependency installation were expanded, and the procedure for dealing with the most common issues was clarified. The update targeted computers running MacOS (M1) and Linux Ubuntu. For some demos, bugs were created in Jira, or other project files were modified besides the readme (details below).

The update involved the following demos:
**1. camera_to_hls**
- [update_camera_to_hls branch](https://github.com/membraneframework/membrane_demo/tree/update_camera_to_hls) was used during tests due to the necessity of updating Bundlex
- OBS virtual camera not found - [bug in Jira](https://membraneframework.atlassian.net/browse/MS-586?atlOrigin=eyJpIjoiYmIyYTEwM2ExM2I4NGQ5NWExMDFlYTlhOWI5ZGY4MjkiLCJwIjoiaiJ9)

**2. rtmp_to_hls**
- Incorrect RTMP server adress in video - [bug in Jira](https://membraneframework.atlassian.net/browse/MS-587?atlOrigin=eyJpIjoiNzAxZjgyMDgwN2I3NDllZmExMTExMDc3NTIzMWU2ZWQiLCJwIjoiaiJ9)

**3. rtp**
**4. rtp_to_hls**
**5. rtsp_to_hls**
- Problem with generating index.m3u8 file - [bug in Jira](https://membraneframework.atlassian.net/browse/MS-593?atlOrigin=eyJpIjoiOTc1YjNiNTVjMjRmNDUwOThkNmUzMjQ5MTExODcyNzMiLCJwIjoiaiJ9)

**6. webrtc_authentication**
- I created missing folders in priv/repo/migrations and added `!/priv/repo/migrations/.gitkeep` to .gitignore, but repo/migrations is still not tracked by git

**7. webrtc_simple**
**8. webrtc_to_hls**
- Removed Absinthe.Plug.Parser from lib/webrtc_to_hls_web/enpoint.ex

**9. webrtc_videoroom**